### PR TITLE
fix: version correctly set on release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,7 @@ builds:
         goarch: arm64
     main: ./cmd/jsm/main.go
     ldflags:
-      - -s -w -X github.com/andyballingall/json-schema-manager/internal/cmd.Version={{.Version}}
+      - -s -w -X github.com/andyballingall/json-schema-manager/internal/app.Version={{.Version}}
 
 archives:
   - formats: [tar.gz]


### PR DESCRIPTION
## Description

.goreleaser.yml had not been updated to inject the version into the app package (it was previously the cmd package but was changed following a refactor)

This PR corrects that.