### PR TITLE
feat(ci): augment badge info on README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ check-coverage:
 cover-html:
 	@go run scripts/tester/main.go --browser -count=1 -race ./...
 
+# Generate coverage badge
+test-badge:
+	@go run scripts/tester/main.go --badge -count=1 -race ./...
+
 # Run linter
 lint:
 	@go run scripts/lint/main.go

--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@
 
 # JSON Schema Manager (jsm)
 
-![Build Status](https://github.com/andyballingall/json-schema-manager/actions/workflows/ci.yml/badge.svg)
+[![Build Status](https://github.com/andyballingall/json-schema-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/andyballingall/json-schema-manager/actions/workflows/ci.yml)
 ![Coverage Status](https://github.com/andyballingall/json-schema-manager/wiki/coverage.svg)
+[![Go Report Card](https://goreportcard.com/badge/github.com/andyballingall/json-schema-manager)](https://goreportcard.com/report/github.com/andyballingall/json-schema-manager)
+[![Go Reference](https://pkg.go.dev/badge/github.com/andyballingall/json-schema-manager.svg)](https://pkg.go.dev/github.com/andyballingall/json-schema-manager)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 JSON Schema Manager (JSM) is a framework that provides a robust workflow and firm foundations for organisations which need to develop, test, deploy, and evolve JSON Schemas over time.
 


### PR DESCRIPTION
This PR fixes the broken coverage indicator on the project home page and introduces a comprehensive suite of professional badges to enhance the repository's presentation.

### Key Changes
Coverage Badge Automation:
Added a --badge flag to 
scripts/tester/main.go
 that generates a dynamic coverage.svg based on total project coverage.
Added a make test-badge target to the Makefile.
Created a new GitHub Action (
.github/workflows/coverage.yml
) that automatically updates the coverage.svg file in the repository's Wiki on every push to 
main
.
### README Enhancements:
Replaced the broken build/coverage links with a professional "Badge Bar."
Added Go Report Card to show code quality metrics.
Added Go Reference (pkg.go.dev) for easy access to API documentation.
Added an explicit MIT License badge.
Maintenance:
Fixed linting issues in the new tester logic (error checking, file permissions, and line length compliance).
Why this approach?
We use a separate workflow to push the coverage badge to the Wiki. This keeps the badge "live" and reflecting the truth of the 
main
 branch without requiring third-party services like Codecov or granting dangerous write permissions to the general CI workflow.

### How to Verify
Run make test-badge locally to verify coverage.svg is generated correctly.
Ensure the GitHub Wiki is initialized on the repository for the automated uploader to work after merging.