### PR TITLE
feat(ci): refined make setup commands targetting different scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
             - name: Install dependencies
               run: |
                   go version
-                  make setup
+                  make setup-ci
 
             - name: Run Linter
               run: make lint

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
 
             - name: Generate Badge
               run: |
-                  make setup
+                  make setup-coverage
                   make test-badge
 
             - name: Update Wiki

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+main

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build run clean test test-race test-cover test-race-coverage cover-html lint fmt snapshot release-check setup
+.PHONY: all build run clean test test-race test-cover test-race-coverage cover-html lint fmt snapshot release-check setup setup-ci setup-coverage
 
 all: build
 
@@ -59,3 +59,11 @@ release-check:
 # Setup development environment
 setup:
 	@go run scripts/setup/main.go
+
+# Setup for CI - skips lefthook installation
+setup-ci:
+	@go run scripts/setup/main.go --workflow ci
+
+# Setup for coverage workflow - minimal tools
+setup-coverage:
+	@go run scripts/setup/main.go --workflow coverage

--- a/scripts/tester/main.go
+++ b/scripts/tester/main.go
@@ -208,18 +208,6 @@ func parseCoverageOutput(output []byte) (failures []string, totalLine string) {
 	exclusions := map[string]float64{
 		// filepath.Abs() error path is unreachable on Darwin
 		"github.com/andyballingall/json-schema-manager/internal/fsh/path_resolver.go:27": 75.0,
-		// os.IsNotExist(err) false path is hard to trigger reliably
-		"github.com/andyballingall/json-schema-manager/internal/schema/registry.go:131": 90.0,
-		// break Loop branch inside select is race-prone item to test
-		"github.com/andyballingall/json-schema-manager/internal/schema/tester.go:346": 94.0,
-		// singleflight double-check cache path is non-deterministic due to goroutine scheduling
-		"github.com/andyballingall/json-schema-manager/internal/schema/registry.go:151": 90.0,
-		// WatchValidation callback execution depends on file system event timing
-		"github.com/andyballingall/json-schema-manager/internal/app/manager.go:193": 97.0,
-		// TextReporter.Write coverage depends on WatchValidation callback timing
-		"github.com/andyballingall/json-schema-manager/internal/report/text.go:38": 98.0,
-		// BuildAll parallel error handling is hard to trigger reliably
-		"github.com/andyballingall/json-schema-manager/internal/schema/dist.go:65": 97.0,
 	}
 
 	scanner := bufio.NewScanner(strings.NewReader(string(output)))


### PR DESCRIPTION
- scripts/setup/main.go now accepts an optional --workflow [workflow-name] tag which allows setup to be tuned for different workflows. If not set, it reverts to assuming a local development environment.