### PR TITLE
fix(ci): update coverage badge detection (#18)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,10 +42,10 @@ jobs:
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
 
-                  if git diff --quiet; then
-                    echo "No changes to coverage badge"
-                  else
-                    git add coverage.svg
-                    git commit -m "chore: update coverage badge"
-                    git push
-                  fi
+                   if ! git status --porcelain | grep -q .; then
+                     echo "No changes to coverage badge"
+                   else
+                     git add coverage.svg
+                     git commit -m "chore: update coverage badge"
+                     git push
+                   fi


### PR DESCRIPTION
## Summary
The coverage workflow wasn't committing the badge to the wiki because `git diff --quiet` only detects changes to tracked files. When `coverage.svg` was copied to the wiki directory, it was an untracked file, so the diff showed nothing and the workflow skipped the commit.
## Fix
Changed from using `git diff --quiet` to `git status --porcelain` to detect changes including untracked files. Now the workflow properly commits and pushes the badge when it's first added or updated.
## Testing
- [x] Workflow runs successfully on main branch push
- [x] Badge appears in wiki repository after workflow completes