### PR TITLE
refactor: repo ownership change (closes #24)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @andyballingall
+* @bitshepherds/JSM-Approvers

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,17 +12,17 @@ formatters:
     - golines
   settings:
     gofumpt:
-      module-path: github.com/andyballingall/json-schema-manager
+      module-path: github.com/bitshepherds/json-schema-manager
     goimports:
       local-prefixes:
-        - github.com/andyballingall/json-schema-manager
+        - github.com/bitshepherds/json-schema-manager
     golines:
       max-len: 120
     gci:
       sections:
         - standard
         - default
-        - prefix(github.com/andyballingall/json-schema-manager)
+        - prefix(github.com/bitshepherds/json-schema-manager)
 
 linters:
   enable:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,7 @@ builds:
         goarch: arm64
     main: ./cmd/jsm/main.go
     ldflags:
-      - -s -w -X github.com/andyballingall/json-schema-manager/internal/app.Version={{.Version}}
+      - -s -w -X github.com/bitshepherds/json-schema-manager/internal/app.Version={{.Version}}
 
 archives:
   - formats: [tar.gz]
@@ -54,11 +54,11 @@ changelog:
 homebrew_casks:
   - name: jsm
     repository:
-      owner: andyballingall
+      owner: bitshepherds
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Casks
-    homepage: "https://github.com/andyballingall/json-schema-manager"
+    homepage: "https://github.com/bitshepherds/json-schema-manager"
     description: "JSON Schema Manager (jsm) - Registry-first tool for managing and validating JSON schemas."
     binaries:
       - jsm

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,7 @@
   "go.useLanguageServer": true,
   "gopls": {
     "formatting.gofumpt": true,
-    "formatting.local": "github.com/andyballingall/json-schema-manager"
+    "formatting.local": "github.com/bitshepherds/json-schema-manager"
   },
   "makefile.configureOnOpen": false,
   "[json]": {

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
+Copyright 2026 Andy Ballingall and Bit Shepherds Limited
+
                                  Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                            Version 2.0, January 2004
+                         http://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # JSON Schema Manager (JSM) <!-- omit in toc -->
 
-[![Build Status](https://github.com/andyballingall/json-schema-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/andyballingall/json-schema-manager/actions/workflows/ci.yml)
-![Coverage Status](https://github.com/andyballingall/json-schema-manager/wiki/coverage.svg#badge)
-[![Go Report Card](https://goreportcard.com/badge/github.com/andyballingall/json-schema-manager)](https://goreportcard.com/report/github.com/andyballingall/json-schema-manager)
+[![Build Status](https://github.com/bitshepherds/json-schema-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/bitshepherds/json-schema-manager/actions/workflows/ci.yml)
+![Coverage Status](https://github.com/bitshepherds/json-schema-manager/wiki/coverage.svg#badge)
+[![Go Report Card](https://goreportcard.com/badge/github.com/bitshepherds/json-schema-manager)](https://goreportcard.com/report/github.com/bitshepherds/json-schema-manager)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 JSON Schemas can be used as powerful contracts to validate data within an organisation - whether it be objects in memory, data at rest in databases or object storage, or data moving between between components across a network via API calls or event streams.
@@ -13,7 +13,7 @@ This repo contains the implementation of the `jsm` CLI tool.
 
 > [!TIP]
 >
-> If you'd like to learn about or use JSM, see [jsm-demo](https://github.com/andyballingall/jsm-demo).
+> If you'd like to learn about or use JSM, see [jsm-demo](https://github.com/bitshepherds/jsm-demo).
 
 ## Contributing
 

--- a/cmd/jsm/integration_test.go
+++ b/cmd/jsm/integration_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/app"
-	"github.com/andyballingall/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/app"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
 )
 
 var binaryPath string

--- a/cmd/jsm/main.go
+++ b/cmd/jsm/main.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/andyballingall/json-schema-manager/internal/app"
+	"github.com/bitshepherds/json-schema-manager/internal/app"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/andyballingall/json-schema-manager
+module github.com/bitshepherds/json-schema-manager
 
 go 1.25.5
 

--- a/internal/app/build_dist.go
+++ b/internal/app/build_dist.go
@@ -3,7 +3,7 @@ package app
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
 )
 
 // NewBuildDistCmd creates a new build-dist command.

--- a/internal/app/check_changes.go
+++ b/internal/app/check_changes.go
@@ -3,7 +3,7 @@ package app
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
 )
 
 // NewCheckChangesCmd creates a new check-changes command.

--- a/internal/app/check_changes_test.go
+++ b/internal/app/check_changes_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
 )
 
 func TestNewCheckChangesCmd(t *testing.T) {

--- a/internal/app/create_registry.go
+++ b/internal/app/create_registry.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
-	"github.com/andyballingall/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
 )
 
 // NewCreateRegistryCmd returns a new cobra command for creating a registry.

--- a/internal/app/create_registry_test.go
+++ b/internal/app/create_registry_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
 )
 
 func TestNewCreateRegistryCmd(t *testing.T) {

--- a/internal/app/create_schema.go
+++ b/internal/app/create_schema.go
@@ -3,7 +3,7 @@ package app
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/andyballingall/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
 )
 
 // NewCreateSchemaCmd returns a new cobra command for creating a schema.

--- a/internal/app/create_schema_test.go
+++ b/internal/app/create_schema_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
 )
 
 func TestCreateSchemaCmd(t *testing.T) {

--- a/internal/app/create_schema_version.go
+++ b/internal/app/create_schema_version.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/andyballingall/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
 )
 
 // NewCreateSchemaVersionCmd returns a new cobra command for creating a schema version.

--- a/internal/app/create_schema_version_test.go
+++ b/internal/app/create_schema_version_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
-	"github.com/andyballingall/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
 )
 
 func TestNewCreateSchemaVersionCmd(t *testing.T) {

--- a/internal/app/logger.go
+++ b/internal/app/logger.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
 )
 
 const (

--- a/internal/app/logger_test.go
+++ b/internal/app/logger_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
 )
 
 func TestSetupLogger(t *testing.T) {

--- a/internal/app/manager.go
+++ b/internal/app/manager.go
@@ -9,10 +9,10 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/repo"
-	"github.com/andyballingall/json-schema-manager/internal/report"
-	"github.com/andyballingall/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/repo"
+	"github.com/bitshepherds/json-schema-manager/internal/report"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
 )
 
 // Manager defines the business logic for JSON schema operations.

--- a/internal/app/manager_test.go
+++ b/internal/app/manager_test.go
@@ -18,11 +18,11 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
-	"github.com/andyballingall/json-schema-manager/internal/repo"
-	"github.com/andyballingall/json-schema-manager/internal/schema"
-	"github.com/andyballingall/json-schema-manager/internal/validator"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/repo"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/validator"
 )
 
 const testConfigData = `

--- a/internal/app/render_schema.go
+++ b/internal/app/render_schema.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
 )
 
 // NewRenderSchemaCmd returns a new cobra command for rendering a schema.

--- a/internal/app/render_schema_test.go
+++ b/internal/app/render_schema_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
-	"github.com/andyballingall/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
 )
 
 func TestNewRenderSchemaCmd(t *testing.T) {

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
-	"github.com/andyballingall/json-schema-manager/internal/repo"
-	"github.com/andyballingall/json-schema-manager/internal/schema"
-	"github.com/andyballingall/json-schema-manager/internal/validator"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/repo"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/validator"
 )
 
 // Version is the current version of jsm, set at build time.

--- a/internal/app/root_test.go
+++ b/internal/app/root_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
-	"github.com/andyballingall/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
 )
 
 func TestRootCmd(t *testing.T) {

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"log/slog"
 
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
 )
 
 // Run executes the application with the given arguments.

--- a/internal/app/run_test.go
+++ b/internal/app/run_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
 )
 
 func TestRun(t *testing.T) {

--- a/internal/app/tag_deployment.go
+++ b/internal/app/tag_deployment.go
@@ -3,7 +3,7 @@ package app
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
 )
 
 // NewTagDeploymentCmd returns a new cobra command for tagging a deployment.

--- a/internal/app/tag_deployment_test.go
+++ b/internal/app/tag_deployment_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
 )
 
 func TestNewTagDeploymentCmd(t *testing.T) {

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/repo"
-	"github.com/andyballingall/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/repo"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
 )
 
 const testConfig = `

--- a/internal/app/validate.go
+++ b/internal/app/validate.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/andyballingall/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
 )
 
 // NewValidateCmd creates a new validate command.

--- a/internal/app/validate_test.go
+++ b/internal/app/validate_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
 )
 
 func TestValidateCmd(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/andyballingall/json-schema-manager/internal/validator"
+	"github.com/bitshepherds/json-schema-manager/internal/validator"
 )
 
 // JsmRegistryConfigFile is the name of the JSM registry configuration file.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/validator"
+	"github.com/bitshepherds/json-schema-manager/internal/validator"
 )
 
 type mockCompiler struct {

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -3,7 +3,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/andyballingall/json-schema-manager/internal/validator"
+	"github.com/bitshepherds/json-schema-manager/internal/validator"
 )
 
 // MustHaveExactlyOneProductionEnvironmentError is returned when the configuration doesn't have exactly one

--- a/internal/fsh/env_provider_test.go
+++ b/internal/fsh/env_provider_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
 )
 
 // mockEnvProvider is a test implementation of EnvProvider.

--- a/internal/fsh/fs_test.go
+++ b/internal/fsh/fs_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
 )
 
 func TestCanonicalPath(t *testing.T) {

--- a/internal/repo/cli_gitter.go
+++ b/internal/repo/cli_gitter.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
 )
 
 // CLIGitter is the concrete implementation of Gitter using the git CLI.

--- a/internal/repo/cli_gitter_test.go
+++ b/internal/repo/cli_gitter_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
 )
 
 func setupTestRepo(t *testing.T) string {

--- a/internal/repo/gitter.go
+++ b/internal/repo/gitter.go
@@ -3,7 +3,7 @@ package repo
 import (
 	"context"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
 )
 
 // JSMDeployTagPrefix is the prefix used for deployment tags.

--- a/internal/report/json.go
+++ b/internal/report/json.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/andyballingall/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
 )
 
 // JSONReporter implements schema.Reporter for JSON output.

--- a/internal/report/reporter_test.go
+++ b/internal/report/reporter_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
 )
 
 func TestTextReporter(t *testing.T) {

--- a/internal/report/text.go
+++ b/internal/report/text.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/andyballingall/json-schema-manager/internal/schema"
+	"github.com/bitshepherds/json-schema-manager/internal/schema"
 )
 
 // TextReporter implements schema.Reporter for plain text output.

--- a/internal/schema/computed.go
+++ b/internal/schema/computed.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/validator"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/validator"
 )
 
 // RenderInfo holds the rendered artefacts for a schema.

--- a/internal/schema/computed_test.go
+++ b/internal/schema/computed_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
 )
 
 func TestComputed_StoreRenderInfo(t *testing.T) {

--- a/internal/schema/dist.go
+++ b/internal/schema/dist.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
-	"github.com/andyballingall/json-schema-manager/internal/repo"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/repo"
 )
 
 // RegistryRootAtGitRootError is returned when the registry root is the same as the git root.

--- a/internal/schema/dist_test.go
+++ b/internal/schema/dist_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
-	"github.com/andyballingall/json-schema-manager/internal/repo"
-	"github.com/andyballingall/json-schema-manager/internal/validator"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/repo"
+	"github.com/bitshepherds/json-schema-manager/internal/validator"
 )
 
 // mockGitter is a test mock for the repo.Gitter interface.

--- a/internal/schema/registry.go
+++ b/internal/schema/registry.go
@@ -9,9 +9,9 @@ import (
 
 	"golang.org/x/sync/singleflight"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
-	"github.com/andyballingall/json-schema-manager/internal/validator"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/validator"
 )
 
 // RootDirEnvVar is the environment variable used to set the registry root directory.

--- a/internal/schema/registry_test.go
+++ b/internal/schema/registry_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
 )
 
 func TestNewRegistry(t *testing.T) {

--- a/internal/schema/renderer.go
+++ b/internal/schema/renderer.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/validator"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/validator"
 )
 
 // Renderer is a go template renderer which converts a source schema into

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"text/template"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/validator"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/validator"
 )
 
 // ID is the canonical ID of a JSON Schema.

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
-	"github.com/andyballingall/json-schema-manager/internal/validator"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/validator"
 )
 
 func TestNew(t *testing.T) {

--- a/internal/schema/spec.go
+++ b/internal/schema/spec.go
@@ -1,7 +1,7 @@
 package schema
 
 import (
-	"github.com/andyballingall/json-schema-manager/internal/validator"
+	"github.com/bitshepherds/json-schema-manager/internal/validator"
 )
 
 // Spec defines a single schema test involving the rendered schema and a test JSON document which

--- a/internal/schema/test_helpers_test.go
+++ b/internal/schema/test_helpers_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/andyballingall/json-schema-manager/internal/config"
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
-	"github.com/andyballingall/json-schema-manager/internal/validator"
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/validator"
 )
 
 // mockValidator is a test implementation of validator.Validator.

--- a/internal/schema/tester_test.go
+++ b/internal/schema/tester_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/validator"
+	"github.com/bitshepherds/json-schema-manager/internal/validator"
 )
 
 func TestTestLog_AddTest(t *testing.T) {

--- a/internal/schema/watcher_test.go
+++ b/internal/schema/watcher_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/andyballingall/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
 )
 
 type mockEventWatcher struct {

--- a/scripts/build/main.go
+++ b/scripts/build/main.go
@@ -21,7 +21,7 @@ func main() {
 	versionOut, _ := versionCmd.Output()
 	version := string(versionOut)
 
-	ldflags := fmt.Sprintf("-X github.com/andyballingall/json-schema-manager/internal/app.Version=%s", version)
+	ldflags := fmt.Sprintf("-X github.com/bitshepherds/json-schema-manager/internal/app.Version=%s", version)
 
 	// Ensure bin directory exists
 	if err := os.MkdirAll("bin", 0o750); err != nil {

--- a/scripts/tester/main.go
+++ b/scripts/tester/main.go
@@ -211,7 +211,7 @@ func parseCoverageOutput(output []byte) (failures []string, totalLine string) {
 	// Function-level exclusions (Package:Function)
 	exclusions := map[string]float64{
 		// filepath.Abs() error path is unreachable on Darwin
-		"github.com/andyballingall/json-schema-manager/internal/fsh/path_resolver.go:27": 75.0,
+		"github.com/bitshepherds/json-schema-manager/internal/fsh/path_resolver.go:27": 75.0,
 	}
 
 	scanner := bufio.NewScanner(strings.NewReader(string(output)))

--- a/user-docs/developing-schemas.md
+++ b/user-docs/developing-schemas.md
@@ -21,12 +21,12 @@
 
 TODO: Move JSM to bitshepherds.com and update this section.
 
-Download the latest binary for your platform from the [GitHub Releases](https://github.com/andyballingall/json-schema-manager/releases) page.
+Download the latest binary for your platform from the [GitHub Releases](https://github.com/bitshepherds/json-schema-manager/releases) page.
 
 Alternatively, if you have Go installed, you can install it directly:
 
 ```bash
-go install github.com/andyballingall/json-schema-manager/cmd/jsm@latest
+go install github.com/bitshepherds/json-schema-manager/cmd/jsm@latest
 ```
 
 TODO: After moving the project to bitshepherds update the section above.


### PR DESCRIPTION
## Summary
Updates all GitHub references from the personal account `andyballingall` to the organisation `bitshepherds` following the repo transfer.
## Changes
- **Go module**: Updated `go.mod` and all import paths to `github.com/bitshepherds/json-schema-manager`
- **CI/CD**: Updated `.goreleaser.yml` (version ldflags, homebrew tap owner, homepage)
- **Linting**: Updated `.golangci.yml` module path configuration
- **VS Code**: Updated `.vscode/settings.json` local import prefix
- **Documentation**: 
  - Updated README.md badges and links
  - Updated user-docs/developing-schemas.md installation instructions
- **License**: Added copyright notice to Apache 2.0 LICENSE (`Copyright 2026 Andy Ballingall and Bit Shepherds Limited`)
- **Codeowners**: Updated to use `@bitshepherds/JSM-Approvers` team
- **Git remote**: Updated origin to `github.com/bitshepherds/json-schema-manager`
## Verification
- Lint: ✅ Passed
- Tests: ✅ All passing with 99.9% coverage