### PR TITLE
fix: strip trailing slashes from search scope for validate watch mode

### DIFF
--- a/internal/schema/searcher.go
+++ b/internal/schema/searcher.go
@@ -31,10 +31,11 @@ type SearchScope string
 
 // NewSearchScope creates a new SearchScope from a string specification.
 func NewSearchScope(s string) (SearchScope, error) {
-	if !validSearchScopeRegex.MatchString(s) {
+	cleanS := strings.TrimRight(s, SearchSeparatorString)
+	if !validSearchScopeRegex.MatchString(cleanS) {
 		return "", &InvalidSearchScopeError{spec: s}
 	}
-	return SearchScope(s), nil
+	return SearchScope(cleanS), nil
 }
 
 // Searcher is used to define the scope of a search for schemas in a registry, and then

--- a/internal/schema/searcher_test.go
+++ b/internal/schema/searcher_test.go
@@ -18,17 +18,37 @@ func TestNewSearchScope(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
+		want    SearchScope
 		wantErr bool
 	}{
 		{
 			name:    "valid single domain",
 			input:   "domain-a",
+			want:    "domain-a",
 			wantErr: false,
 		},
 		{
 			name:    "valid multi-level path",
 			input:   "domain-a/subdomain-b/family-c/1/0/0",
+			want:    "domain-a/subdomain-b/family-c/1/0/0",
 			wantErr: false,
+		},
+		{
+			name:    "trailing slash is stripped",
+			input:   "domain-a/subdomain-b/",
+			want:    "domain-a/subdomain-b",
+			wantErr: false,
+		},
+		{
+			name:    "multiple trailing slashes are stripped",
+			input:   "domain-a/subdomain-b//",
+			want:    "domain-a/subdomain-b",
+			wantErr: false,
+		},
+		{
+			name:    "only slashes is invalid",
+			input:   "//",
+			wantErr: true,
 		},
 		{
 			name:    "root scope is invalid via NewSearchScope",
@@ -55,7 +75,7 @@ func TestNewSearchScope(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, SearchScope(tt.input), s)
+				assert.Equal(t, tt.want, s)
 			}
 		})
 	}


### PR DESCRIPTION
The `jsm validate -w` command previously failed to trigger on changes when provided with a search scope containing a trailing slash (e.g. 'finance/payments/'). This occurred because the trailing slash would cause the `Key.InScope` check to incorrectly filter out watcher events.
This commit updates [NewSearchScope](cci:1://file:///Users/andy/dev/bitshepherds/json-schema-manager/internal/schema/searcher.go:31:0-38:1) to gracefully strip trailing slashes from the search scope string before validation, resolving the watch mode issue. It also introduces comprehensive test cases to verify the fix and prevent regressions.
Fixes #27