### PR TITLE
fix: confirm subset path in watch mode (#26)

### DIFF
--- a/demo-registry/domain-a/domain-a-b/entity-a/1/0/0/pass/all-fields-set.json
+++ b/demo-registry/domain-a/domain-a-b/entity-a/1/0/0/pass/all-fields-set.json
@@ -1,11 +1,11 @@
 {
-    "propA": 42,
-    "propB": {
-        "propBA": [
-            1,
-            2,
-            3
-        ],
-        "probBB": "Hello World"
-    }
+  "propA": 42,
+  "propB": {
+    "propBA": [
+      1,
+      2,
+      3
+    ],
+    "probBB": "Hello World"
+  }
 }

--- a/internal/app/manager.go
+++ b/internal/app/manager.go
@@ -231,7 +231,7 @@ func (m *CLIManager) WatchValidation(ctx context.Context, target schema.Resolved
 		}()
 	}
 
-	return watcher.Watch(ctx, callback)
+	return watcher.Watch(ctx, target, callback)
 }
 
 func (m *CLIManager) handleWatchEvent(ctx context.Context, event schema.WatchEvent, target schema.ResolvedTarget,

--- a/internal/app/manager_test.go
+++ b/internal/app/manager_test.go
@@ -406,7 +406,7 @@ func TestCLIManager_WatchValidation(t *testing.T) {
 
 	t.Run("WatchValidation - filtered events", func(t *testing.T) {
 		t.Parallel()
-		registry, key, _ := setupWatchTest(t)
+		registry, key, s := setupWatchTest(t)
 
 		// Create a DIFFERENT schema BEFORE starting the watcher (so it's watched)
 		k2 := schema.Key("other_domain_otherfamily_1_0_0")
@@ -428,8 +428,12 @@ func TestCLIManager_WatchValidation(t *testing.T) {
 
 		<-readyChan
 
-		// Modify the OTHER schema file to trigger an event (should be filtered by Key)
-		require.NoError(t, os.WriteFile(s2.Path(schema.FilePath), []byte(`{"type":"object"}`), 0o600))
+		// Modify the schema inside the exact watched directory but with a mismatched key (should be filtered by Key)
+		require.NoError(t, os.WriteFile(
+			filepath.Join(s.Path(schema.HomeDir), "other_key_1_0_0.schema.json"),
+			[]byte(`{"type":"object"}`),
+			0o600,
+		))
 
 		time.Sleep(500 * time.Millisecond)
 		cancel()
@@ -461,8 +465,12 @@ func TestCLIManager_WatchValidation(t *testing.T) {
 
 		<-readyChan
 
-		// Modify the OTHER scope schema file to trigger an event (should be filtered by Scope)
-		require.NoError(t, os.WriteFile(s3.Path(schema.FilePath), []byte(`{"type":"object"}`), 0o600))
+		// Modify a schema physically inside the scope path but with a key that implies a different scope
+		require.NoError(t, os.WriteFile(
+			filepath.Join(registry.RootDirectory(), "domain", "family", "other_schema_1_0_0.schema.json"),
+			[]byte(`{"type":"object"}`),
+			0o600,
+		))
 
 		time.Sleep(200 * time.Millisecond)
 		cancel()

--- a/internal/schema/searcher.go
+++ b/internal/schema/searcher.go
@@ -31,10 +31,11 @@ type SearchScope string
 
 // NewSearchScope creates a new SearchScope from a string specification.
 func NewSearchScope(s string) (SearchScope, error) {
-	if !validSearchScopeRegex.MatchString(s) {
+	cleanS := strings.TrimRight(s, SearchSeparatorString)
+	if !validSearchScopeRegex.MatchString(cleanS) {
 		return "", &InvalidSearchScopeError{spec: s}
 	}
-	return SearchScope(s), nil
+	return SearchScope(cleanS), nil
 }
 
 // Searcher is used to define the scope of a search for schemas in a registry, and then

--- a/internal/schema/searcher_test.go
+++ b/internal/schema/searcher_test.go
@@ -18,17 +18,37 @@ func TestNewSearchScope(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
+		want    SearchScope
 		wantErr bool
 	}{
 		{
 			name:    "valid single domain",
 			input:   "domain-a",
+			want:    "domain-a",
 			wantErr: false,
 		},
 		{
 			name:    "valid multi-level path",
 			input:   "domain-a/subdomain-b/family-c/1/0/0",
+			want:    "domain-a/subdomain-b/family-c/1/0/0",
 			wantErr: false,
+		},
+		{
+			name:    "trailing slash is stripped",
+			input:   "domain-a/subdomain-b/",
+			want:    "domain-a/subdomain-b",
+			wantErr: false,
+		},
+		{
+			name:    "multiple trailing slashes are stripped",
+			input:   "domain-a/subdomain-b//",
+			want:    "domain-a/subdomain-b",
+			wantErr: false,
+		},
+		{
+			name:    "only slashes is invalid",
+			input:   "//",
+			wantErr: true,
 		},
 		{
 			name:    "root scope is invalid via NewSearchScope",
@@ -55,7 +75,7 @@ func TestNewSearchScope(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, SearchScope(tt.input), s)
+				assert.Equal(t, tt.want, s)
 			}
 		})
 	}

--- a/internal/schema/watcher.go
+++ b/internal/schema/watcher.go
@@ -72,18 +72,28 @@ func NewWatcher(r *Registry, logger *slog.Logger) *Watcher {
 
 // Watch starts monitoring the registry for changes. It calls the provided callback
 // whenever a relevant change is detected. It blocks until the context is cancelled.
-func (w *Watcher) Watch(ctx context.Context, callback func(WatchEvent)) error {
+func (w *Watcher) Watch(ctx context.Context, target ResolvedTarget, callback func(WatchEvent)) error {
 	watcher, err := w.newWatcher()
 	if err != nil {
 		return err
 	}
 	defer func() { _ = watcher.Close() }()
 
-	if err := w.addRecursive(watcher, w.registry.RootDirectory()); err != nil {
+	targetPath := w.registry.RootDirectory()
+	if target.Scope != nil && *target.Scope != "" {
+		targetPath = filepath.Join(targetPath, filepath.FromSlash(string(*target.Scope)))
+	} else if target.Key != nil {
+		s, err := w.registry.GetSchemaByKey(*target.Key)
+		if err == nil {
+			targetPath = filepath.Dir(s.Path(FilePath))
+		}
+	}
+
+	if err := w.addRecursive(watcher, targetPath); err != nil {
 		return err
 	}
 
-	w.logger.Info("Watching for changes", "root", w.registry.RootDirectory())
+	w.logger.Info("Watching for changes", "target", targetPath)
 	if w.Ready != nil {
 		close(w.Ready)
 	}

--- a/internal/schema/watcher_test.go
+++ b/internal/schema/watcher_test.go
@@ -58,7 +58,7 @@ func TestWatcher(t *testing.T) {
 
 		events := make(chan WatchEvent, 10)
 		go func() {
-			_ = watcher.Watch(ctx, func(e WatchEvent) {
+			_ = watcher.Watch(ctx, ResolvedTarget{}, func(e WatchEvent) {
 				events <- e
 			})
 		}()
@@ -94,7 +94,7 @@ func TestWatcher(t *testing.T) {
 
 		events := make(chan WatchEvent, 10)
 		go func() {
-			_ = watcher.Watch(ctx, func(e WatchEvent) {
+			_ = watcher.Watch(ctx, ResolvedTarget{}, func(e WatchEvent) {
 				events <- e
 			})
 		}()
@@ -132,7 +132,7 @@ func TestWatcher(t *testing.T) {
 
 		done := make(chan struct{})
 		go func() {
-			err := watcher.Watch(innerCtx, func(_ WatchEvent) {})
+			err := watcher.Watch(innerCtx, ResolvedTarget{}, func(_ WatchEvent) {})
 			assert.ErrorIs(t, err, context.Canceled)
 			close(done)
 		}()
@@ -269,7 +269,7 @@ func TestWatcher(t *testing.T) {
 		w.newWatcher = func() (eventWatcher, error) {
 			return nil, errors.New("factory error")
 		}
-		err := w.Watch(context.Background(), func(_ WatchEvent) {})
+		err := w.Watch(context.Background(), ResolvedTarget{}, func(_ WatchEvent) {})
 		assert.ErrorContains(t, err, "factory error")
 	})
 
@@ -284,7 +284,7 @@ func TestWatcher(t *testing.T) {
 
 		events := make(chan WatchEvent, 10)
 		go func() {
-			_ = w.Watch(ctx, func(e WatchEvent) {
+			_ = w.Watch(ctx, ResolvedTarget{}, func(e WatchEvent) {
 				events <- e
 			})
 		}()
@@ -326,7 +326,7 @@ func TestWatcher(t *testing.T) {
 
 		done := make(chan error, 1)
 		go func() {
-			done <- w.Watch(ctx, func(_ WatchEvent) {})
+			done <- w.Watch(ctx, ResolvedTarget{}, func(_ WatchEvent) {})
 		}()
 
 		<-w.Ready
@@ -398,7 +398,7 @@ func TestWatcher(t *testing.T) {
 		w.newWatcher = func() (eventWatcher, error) {
 			return nil, fmt.Errorf("newWatcher fail")
 		}
-		err := w.Watch(context.Background(), nil)
+		err := w.Watch(context.Background(), ResolvedTarget{}, nil)
 		require.Error(t, err)
 
 		// 2. addRecursive error (line 52)
@@ -411,7 +411,7 @@ func TestWatcher(t *testing.T) {
 		reg, _ := NewRegistry(tmp, &mockCompiler{}, fsh.NewPathResolver(), fsh.NewEnvProvider())
 		w = NewWatcher(reg, logger)
 		require.NoError(t, os.RemoveAll(tmp)) // Make root non-existent
-		err = w.Watch(context.Background(), nil)
+		err = w.Watch(context.Background(), ResolvedTarget{}, nil)
 		assert.Error(t, err)
 	})
 
@@ -431,7 +431,7 @@ func TestWatcher(t *testing.T) {
 
 		done := make(chan error, 1)
 		go func() {
-			done <- w.Watch(context.Background(), func(_ WatchEvent) {})
+			done <- w.Watch(context.Background(), ResolvedTarget{}, func(_ WatchEvent) {})
 		}()
 
 		<-w.Ready

--- a/user-docs/developing-schemas.md
+++ b/user-docs/developing-schemas.md
@@ -41,7 +41,7 @@ The Registry Root is the root directory of the JSON Schema registry. It is the d
 
 You can specify the Registry Root in the following ways:
 
-- with the `jsm` CLI flag: `--registry-root` 
+- with the `jsm` CLI flag: `--registry` 
 - with the environment variable: `JSM_REGISTRY_ROOT`.
 
 The flag overrides the environment variable.
@@ -62,7 +62,7 @@ It should be the root of a git repository.
 
 The first time you use JSON Schema Manager, you will need to initialise a new JSM Registry.
 
-`jsm init` - creates or initialises a new JSM Registry at the path described by the `--registry-root` flag or the `JSM_REGISTRY_ROOT` environment variable. (See [Registry root](#registry-root))
+`jsm init` - creates or initialises a new JSM Registry at the path described by the `--registry` flag or the `JSM_REGISTRY_ROOT` environment variable. (See [Registry root](#registry-root))
 
 E.g. 
 
@@ -73,7 +73,7 @@ jsm init
 
 To create a new registry at `/path/to/registry`:
 ```bash
-jsm init --registry-root="/path/to/registry"
+jsm init --registry="/path/to/registry"
 ```
 
 The command will fail if the registry was already initialised or the path cannot be created.


### PR DESCRIPTION
Configures the watcher to determine the absolute target path of the
specific subset, logs it clearly, and restricts filesystem watching
to only that specific path.
- Modified Watcher.Watch to accept ResolvedTarget
- Updated WatchValidation to pass target to the watcher
- Adjusted tests to reflect signature changes

Closes #26