### PR TITLE
fix: flaky test - race condition in PathResolver (#33)

### DIFF
--- a/internal/fsh/path_resolver_test.go
+++ b/internal/fsh/path_resolver_test.go
@@ -3,6 +3,7 @@ package fsh
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -92,9 +93,8 @@ func TestStandardPathResolver(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	//nolint:paralleltest // os.Chdir mutates global state
 	t.Run("CanonicalPath fails with deleted CWD", func(t *testing.T) {
-		t.Parallel()
-		// This test might not fail on all Darwin systems due to Getwd caching
 		tmp, err := os.MkdirTemp("", "vanishing-dir")
 		require.NoError(t, err)
 
@@ -109,10 +109,12 @@ func TestStandardPathResolver(t *testing.T) {
 
 		resolver := NewPathResolver()
 		_, err = resolver.CanonicalPath(".")
-		// We don't assert error here because it's flaky on Darwin,
-		// but it's the suggested method.
-		if err != nil {
-			t.Logf("Successfully triggered error: %v", err)
+		if runtime.GOOS == "darwin" {
+			// Darwin caches the working directory path, so Getwd may
+			// succeed even after the directory is removed.
+			t.Logf("darwin: CanonicalPath error (may be nil): %v", err)
+		} else {
+			require.Error(t, err)
 		}
 	})
 


### PR DESCRIPTION
This PR resolves a race condition in the `internal/fsh` package tests that was causing intermittent failures on Linux CI. The issue was caused by a sub-test that mutated the global process working directory while running in parallel with other tests.
## Changes
### `internal/fsh/path_resolver_test.go`
- **Isolated global state mutation**: Removed `t.Parallel()` from the `CanonicalPath fails with deleted CWD` sub-test. This sub-test calls `os.Chdir`, which affects the entire process and was corrupting the environment for concurrent tests (notably `Abs returns absolute path`).
- **Added lint suppression**: Added `//nolint:paralleltest` on its own line to satisfy the linter and document the intentional lack of parallelism.
- **Improved error assertions**: 
    - Added a `runtime.GOOS` check to enforce strict error assertions on Linux.
    - This ensures that the error branch in `path_resolver.go` is actually exercised and verified on CI (Linux), while remaining tolerant of the cached `Getwd` behavior on macOS (Darwin).
- **Imports**: Added `runtime` to support the OS check.
## Verification Results
### Automated Tests
- **Lint**: `make lint` passes (0 issues).
- **Coverage**: `make test-race-coverage` passes with `100%` coverage maintained for internal packages.
- **Race Detection**: `go test -race -count=20 ./internal/fsh/` verified to be stable locally.
### CI/CD
This should resolve the intermittent `getwd: no such file or directory` failures observed in the GitHub Actions pipeline.
Closes #33