### PR TITLE
Schema Collapsing Feature

### DIFF
--- a/internal/app/build_dist.go
+++ b/internal/app/build_dist.go
@@ -9,6 +9,7 @@ import (
 // NewBuildDistCmd creates a new build-dist command.
 func NewBuildDistCmd(m Manager) *cobra.Command {
 	var all bool
+	var collapse bool
 
 	cmd := &cobra.Command{
 		Use:   "build-dist [environment]",
@@ -24,13 +25,18 @@ mutations are forbidden.
 If the --all (-a) flag is used, all schemas in the registry are rendered and written 
 to the dist directory, skipping the mutation check.
 
+If the --collapse (-C) flag is used, external $ref references to other JSM-managed
+schemas in the same registry are resolved and inlined into a $defs block within each
+schema. This produces self-contained schemas that can be used without loading their
+dependencies. The collapse is recursive: transitive dependencies are also inlined.
+
 WARNING: Using the --all (-a) flag is NOT recommended in a deployment pipeline, as it 
 bypasses safety checks and may deploy unintended changes. It is primarily intended 
 for local troubleshooting or manual overrides.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			env := args[0]
-			if err := m.BuildDist(cmd.Context(), config.Env(env), all); err != nil {
+			if err := m.BuildDist(cmd.Context(), config.Env(env), all, collapse); err != nil {
 				return err
 			}
 			return nil
@@ -38,6 +44,8 @@ for local troubleshooting or manual overrides.`,
 	}
 
 	cmd.Flags().BoolVarP(&all, "all", "a", false, "Render and build all schemas, skipping mutation checks")
+	cmd.Flags().BoolVarP(&collapse, "collapse", "C", false,
+		"Inline external $ref dependencies into each schema's $defs block")
 
 	return cmd
 }

--- a/internal/app/manager.go
+++ b/internal/app/manager.go
@@ -25,10 +25,10 @@ type Manager interface {
 	Registry() *schema.Registry
 	CreateSchema(domainAndFamilyName string) (schema.Key, error)
 	CreateSchemaVersion(k schema.Key, rt schema.ReleaseType) (schema.Key, error)
-	RenderSchema(ctx context.Context, target schema.ResolvedTarget, env config.Env) ([]byte, error)
+	RenderSchema(ctx context.Context, target schema.ResolvedTarget, env config.Env, collapse bool) ([]byte, error)
 	CheckChanges(ctx context.Context, envName config.Env) error
 	TagDeployment(ctx context.Context, envName config.Env) error
-	BuildDist(ctx context.Context, envName config.Env, all bool) error
+	BuildDist(ctx context.Context, envName config.Env, all, collapse bool) error
 }
 
 // Ensure the interface is satisfied.
@@ -90,8 +90,13 @@ func (l *LazyManager) CreateSchemaVersion(k schema.Key, rt schema.ReleaseType) (
 }
 
 // RenderSchema implements the Manager interface.
-func (l *LazyManager) RenderSchema(ctx context.Context, target schema.ResolvedTarget, env config.Env) ([]byte, error) {
-	return l.check().RenderSchema(ctx, target, env)
+func (l *LazyManager) RenderSchema(
+	ctx context.Context,
+	target schema.ResolvedTarget,
+	env config.Env,
+	collapse bool,
+) ([]byte, error) {
+	return l.check().RenderSchema(ctx, target, env, collapse)
 }
 
 // CheckChanges implements the Manager interface.
@@ -105,8 +110,8 @@ func (l *LazyManager) TagDeployment(ctx context.Context, envName config.Env) err
 }
 
 // BuildDist implements the Manager interface.
-func (l *LazyManager) BuildDist(ctx context.Context, envName config.Env, all bool) error {
-	return l.check().BuildDist(ctx, envName, all)
+func (l *LazyManager) BuildDist(ctx context.Context, envName config.Env, all, collapse bool) error {
+	return l.check().BuildDist(ctx, envName, all, collapse)
 }
 
 // Ensure the interface is satisfied.
@@ -283,8 +288,13 @@ func (m *CLIManager) handleWatchEvent(ctx context.Context, event schema.WatchEve
 }
 
 // RenderSchema renders a schema for a specific environment.
-func (m *CLIManager) RenderSchema(_ context.Context, target schema.ResolvedTarget, env config.Env) ([]byte, error) {
-	m.logger.Debug("rendering schema", "target", target, "env", env)
+func (m *CLIManager) RenderSchema(
+	_ context.Context,
+	target schema.ResolvedTarget,
+	env config.Env,
+	collapse bool,
+) ([]byte, error) {
+	m.logger.Debug("rendering schema", "target", target, "env", env, "collapse", collapse)
 
 	if target.Key == nil {
 		return nil, &schema.NoSchemaTargetsError{}
@@ -321,6 +331,11 @@ func (m *CLIManager) RenderSchema(_ context.Context, target schema.ResolvedTarge
 	ri, err := m.registry.CoordinateRender(s, envCfg)
 	if err != nil {
 		return nil, err
+	}
+
+	if collapse {
+		inliner := schema.NewInliner(m.registry, envCfg)
+		return inliner.Collapse(ri.Rendered)
 	}
 
 	return ri.Rendered, nil
@@ -396,13 +411,13 @@ func (m *CLIManager) TagDeployment(ctx context.Context, envName config.Env) erro
 }
 
 // BuildDist builds a distribution directory for the given environment.
-func (m *CLIManager) BuildDist(ctx context.Context, envName config.Env, all bool) error {
-	m.logger.Debug("building distribution", "env", envName, "all", all)
+func (m *CLIManager) BuildDist(ctx context.Context, envName config.Env, all, collapse bool) error {
+	m.logger.Debug("building distribution", "env", envName, "all", all, "collapse", collapse)
 
 	var count int
 	var err error
 	if all {
-		count, err = m.distBuilder.BuildAll(ctx, envName)
+		count, err = m.distBuilder.BuildAll(ctx, envName, collapse)
 	} else {
 		// Check for mutations first
 		if ccErr := m.CheckChanges(ctx, envName); ccErr != nil {
@@ -414,7 +429,7 @@ func (m *CLIManager) BuildDist(ctx context.Context, envName config.Env, all bool
 			return anchorErr
 		}
 
-		count, err = m.distBuilder.BuildChanged(ctx, envName, anchor)
+		count, err = m.distBuilder.BuildChanged(ctx, envName, anchor, collapse)
 	}
 
 	if err != nil {

--- a/internal/app/manager_test.go
+++ b/internal/app/manager_test.go
@@ -97,14 +97,14 @@ type MockDistBuilder struct {
 	SetNumWorkersFunc func(n int)
 }
 
-func (m *MockDistBuilder) BuildAll(ctx context.Context, env config.Env) (int, error) {
+func (m *MockDistBuilder) BuildAll(ctx context.Context, env config.Env, _ bool) (int, error) {
 	if m.BuildAllFunc != nil {
 		return m.BuildAllFunc(ctx, env)
 	}
 	return 0, nil
 }
 
-func (m *MockDistBuilder) BuildChanged(ctx context.Context, env config.Env, anchor repo.Revision) (int, error) {
+func (m *MockDistBuilder) BuildChanged(ctx context.Context, env config.Env, anchor repo.Revision, _ bool) (int, error) {
 	if m.BuildChangedFunc != nil {
 		return m.BuildChangedFunc(ctx, env, anchor)
 	}
@@ -632,7 +632,7 @@ func TestCLIManager_RenderSchema(t *testing.T) {
 		require.NoError(t, os.WriteFile(s.Path(schema.FilePath), []byte("{}"), 0o600))
 
 		target := schema.ResolvedTarget{Key: &baseKey}
-		rendered, err := mgr.RenderSchema(context.Background(), target, config.Env("prod"))
+		rendered, err := mgr.RenderSchema(context.Background(), target, config.Env("prod"), false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, rendered)
 	})
@@ -649,7 +649,7 @@ func TestCLIManager_RenderSchema(t *testing.T) {
 		require.NoError(t, os.WriteFile(s.Path(schema.FilePath), []byte("{}"), 0o600))
 
 		target := schema.ResolvedTarget{Key: &baseKey}
-		rendered, err := mgr.RenderSchema(context.Background(), target, "")
+		rendered, err := mgr.RenderSchema(context.Background(), target, "", false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, rendered)
 	})
@@ -662,7 +662,7 @@ func TestCLIManager_RenderSchema(t *testing.T) {
 
 		baseKey := schema.Key("d1_f1_1_0_0")
 		target := schema.ResolvedTarget{Key: &baseKey}
-		_, err := mgr.RenderSchema(context.Background(), target, "invalid")
+		_, err := mgr.RenderSchema(context.Background(), target, "invalid", false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid environment: 'invalid'. Valid environments are: 'prod'")
 	})
@@ -674,7 +674,7 @@ func TestCLIManager_RenderSchema(t *testing.T) {
 		mgr := NewCLIManager(logger, registry, tester, &MockGitter{}, nil, io.Discard)
 
 		target := schema.ResolvedTarget{}
-		_, err := mgr.RenderSchema(context.Background(), target, "prod")
+		_, err := mgr.RenderSchema(context.Background(), target, "prod", false)
 		require.Error(t, err)
 		assert.ErrorAs(t, err, new(*schema.NoSchemaTargetsError))
 	})
@@ -687,7 +687,7 @@ func TestCLIManager_RenderSchema(t *testing.T) {
 
 		baseKey := schema.Key("d1_f1_1_0_0")
 		target := schema.ResolvedTarget{Key: &baseKey}
-		_, vErr := mgr.RenderSchema(context.Background(), target, "prod")
+		_, vErr := mgr.RenderSchema(context.Background(), target, "prod", false)
 		require.Error(t, vErr)
 	})
 
@@ -699,7 +699,7 @@ func TestCLIManager_RenderSchema(t *testing.T) {
 
 		baseKey := schema.Key("missing_1_0_0")
 		target := schema.ResolvedTarget{Key: &baseKey}
-		_, err := mgr.RenderSchema(context.Background(), target, "prod")
+		_, err := mgr.RenderSchema(context.Background(), target, "prod", false)
 		require.Error(t, err)
 	})
 
@@ -716,7 +716,44 @@ func TestCLIManager_RenderSchema(t *testing.T) {
 		require.NoError(t, os.WriteFile(s.Path(schema.FilePath), []byte("{ invalid"), 0o600))
 
 		target := schema.ResolvedTarget{Key: &baseKey}
-		_, err := mgr.RenderSchema(context.Background(), target, "prod")
+		_, err := mgr.RenderSchema(context.Background(), target, "prod", false)
+		require.Error(t, err)
+	})
+
+	t.Run("collapse success", func(t *testing.T) {
+		t.Parallel()
+		registry := setupTestRegistry(t)
+		tester := schema.NewTester(registry)
+		mgr := NewCLIManager(logger, registry, tester, &MockGitter{}, nil, io.Discard)
+
+		baseKey := schema.Key("d1_f1_1_0_0")
+		s := schema.New(baseKey, registry)
+		require.NoError(t, os.MkdirAll(s.Path(schema.HomeDir), 0o755))
+		require.NoError(t, os.WriteFile(s.Path(schema.FilePath), []byte(`{"type": "object"}`), 0o600))
+
+		target := schema.ResolvedTarget{Key: &baseKey}
+		rendered, err := mgr.RenderSchema(context.Background(), target, "prod", true)
+		require.NoError(t, err)
+		assert.NotEmpty(t, rendered)
+	})
+
+	t.Run("collapse error", func(t *testing.T) {
+		t.Parallel()
+		registry := setupTestRegistry(t)
+		tester := schema.NewTester(registry)
+		mgr := NewCLIManager(logger, registry, tester, &MockGitter{}, nil, io.Discard)
+
+		baseKey := schema.Key("d1_f1_1_0_0")
+		s := schema.New(baseKey, registry)
+		require.NoError(t, os.MkdirAll(s.Path(schema.HomeDir), 0o755))
+
+		// Unresolvable reference to an missing JSM schema will trigger an error in Collapse
+		badJSON := `{"properties": {"a": {` +
+			`"$ref": "https://json-schemas.internal.myorg.io/domain_missing_1_0_0.schema.json"}}}`
+		require.NoError(t, os.WriteFile(s.Path(schema.FilePath), []byte(badJSON), 0o600))
+
+		target := schema.ResolvedTarget{Key: &baseKey}
+		_, err := mgr.RenderSchema(context.Background(), target, "prod", true)
 		require.Error(t, err)
 	})
 
@@ -745,11 +782,11 @@ func TestCLIManager_RenderSchema(t *testing.T) {
 		target := schema.ResolvedTarget{Key: &baseKey}
 
 		// Test prod
-		_, err = mgr.RenderSchema(context.Background(), target, "prod")
+		_, err = mgr.RenderSchema(context.Background(), target, "prod", false)
 		require.NoError(t, err)
 
 		// Test dev
-		_, err = mgr.RenderSchema(context.Background(), target, "dev")
+		_, err = mgr.RenderSchema(context.Background(), target, "dev", false)
 		require.NoError(t, err)
 	})
 
@@ -769,7 +806,7 @@ func TestCLIManager_RenderSchema(t *testing.T) {
 		t.Cleanup(func() { _ = os.Chmod(homedir, 0o755) })
 
 		target := schema.ResolvedTarget{Key: &baseKey}
-		_, err := mgr.RenderSchema(context.Background(), target, "prod")
+		_, err := mgr.RenderSchema(context.Background(), target, "prod", false)
 		require.Error(t, err)
 	})
 
@@ -784,7 +821,7 @@ func TestCLIManager_RenderSchema(t *testing.T) {
 		require.NoError(t, os.WriteFile(s.Path(schema.FilePath), []byte("{{ bad }"), 0o600))
 
 		target := schema.ResolvedTarget{Key: &baseKey}
-		_, err := mgr.RenderSchema(context.Background(), target, "prod")
+		_, err := mgr.RenderSchema(context.Background(), target, "prod", false)
 		require.Error(t, err)
 	})
 
@@ -800,7 +837,7 @@ func TestCLIManager_RenderSchema(t *testing.T) {
 		require.NoError(t, os.WriteFile(s.Path(schema.FilePath), []byte("{{ JSM \"!!\" }}"), 0o600))
 
 		target := schema.ResolvedTarget{Key: &baseKey}
-		_, err := mgr.RenderSchema(context.Background(), target, "prod")
+		_, err := mgr.RenderSchema(context.Background(), target, "prod", false)
 		require.Error(t, err)
 	})
 
@@ -816,7 +853,7 @@ func TestCLIManager_RenderSchema(t *testing.T) {
 		require.NoError(t, os.WriteFile(s.Path(schema.FilePath), []byte("{{ JSM \"missing_dep_1_0_0\" }}"), 0o600))
 
 		target := schema.ResolvedTarget{Key: &baseKey}
-		_, err := mgr.RenderSchema(context.Background(), target, "prod")
+		_, err := mgr.RenderSchema(context.Background(), target, "prod", false)
 		require.Error(t, err)
 	})
 
@@ -834,7 +871,7 @@ func TestCLIManager_RenderSchema(t *testing.T) {
 		require.NoError(t, os.WriteFile(s.Path(schema.FilePath), []byte("{}"), 0o600))
 
 		target := schema.ResolvedTarget{Key: &baseKey}
-		_, err := mgr.RenderSchema(context.Background(), target, "prod")
+		_, err := mgr.RenderSchema(context.Background(), target, "prod", false)
 		require.Error(t, err)
 	})
 }
@@ -1234,7 +1271,7 @@ func TestCLIManager_BuildDist(t *testing.T) {
 		}
 		mgr := NewCLIManager(logger, registry, nil, &MockGitter{}, mockBuilder, io.Discard)
 
-		err := mgr.BuildDist(context.Background(), "prod", true)
+		err := mgr.BuildDist(context.Background(), "prod", true, false)
 		require.NoError(t, err)
 	})
 
@@ -1249,7 +1286,7 @@ func TestCLIManager_BuildDist(t *testing.T) {
 		}
 		mgr := NewCLIManager(logger, registry, nil, &MockGitter{}, mockBuilder, io.Discard)
 
-		err := mgr.BuildDist(context.Background(), "prod", false)
+		err := mgr.BuildDist(context.Background(), "prod", false, false)
 		require.NoError(t, err)
 	})
 
@@ -1263,7 +1300,7 @@ func TestCLIManager_BuildDist(t *testing.T) {
 		}
 		mgr := NewCLIManager(logger, registry, nil, &MockGitter{}, mockBuilder, io.Discard)
 
-		err := mgr.BuildDist(context.Background(), "prod", true)
+		err := mgr.BuildDist(context.Background(), "prod", true, false)
 		require.NoError(t, err)
 	})
 
@@ -1277,7 +1314,7 @@ func TestCLIManager_BuildDist(t *testing.T) {
 		}
 		mgr := NewCLIManager(logger, registry, nil, &MockGitter{}, mockBuilder, io.Discard)
 
-		err := mgr.BuildDist(context.Background(), "prod", true)
+		err := mgr.BuildDist(context.Background(), "prod", true, false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "build failed")
 	})
@@ -1293,7 +1330,7 @@ func TestCLIManager_BuildDist(t *testing.T) {
 		}
 		mgr := NewCLIManager(logger, registry, nil, mockGitter, nil, io.Discard)
 
-		err := mgr.BuildDist(context.Background(), "prod", false)
+		err := mgr.BuildDist(context.Background(), "prod", false, false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot modify deployed schemas")
 	})
@@ -1313,7 +1350,7 @@ func TestCLIManager_BuildDist(t *testing.T) {
 		}
 		mgr := NewCLIManager(logger, registry, nil, mockGitter, nil, io.Discard)
 
-		err := mgr.BuildDist(context.Background(), "prod", false)
+		err := mgr.BuildDist(context.Background(), "prod", false, false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "git anchor failed")
 	})
@@ -1328,7 +1365,7 @@ func TestCLIManager_BuildDist(t *testing.T) {
 		}
 		mgr := NewCLIManager(logger, registry, nil, &MockGitter{}, mockBuilder, io.Discard)
 
-		err := mgr.BuildDist(context.Background(), "prod", false)
+		err := mgr.BuildDist(context.Background(), "prod", false, false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "build changed failed")
 	})
@@ -1340,7 +1377,7 @@ func TestNewBuildDistCmd(t *testing.T) {
 		t.Parallel()
 		mockMgr := &MockManager{}
 		cmd := NewBuildDistCmd(mockMgr)
-		mockMgr.On("BuildDist", mock.Anything, config.Env("prod"), false).Return(nil)
+		mockMgr.On("BuildDist", mock.Anything, config.Env("prod"), false, false).Return(nil)
 		cmd.SetArgs([]string{"prod"})
 		err := cmd.Execute()
 		require.NoError(t, err)
@@ -1351,7 +1388,7 @@ func TestNewBuildDistCmd(t *testing.T) {
 		t.Parallel()
 		mockMgr := &MockManager{}
 		cmd := NewBuildDistCmd(mockMgr)
-		mockMgr.On("BuildDist", mock.Anything, config.Env("prod"), false).Return(errors.New("build failed"))
+		mockMgr.On("BuildDist", mock.Anything, config.Env("prod"), false, false).Return(errors.New("build failed"))
 		cmd.SetArgs([]string{"prod"})
 		err := cmd.Execute()
 		require.Error(t, err)
@@ -1415,10 +1452,15 @@ func TestLazyManager_Delegation(t *testing.T) {
 	assert.Equal(t, schema.Key("domain_family_1_1_0"), key3)
 
 	// Test RenderSchema delegation
-	mockMgr.On("RenderSchema", ctx, target, config.Env("prod")).Return([]byte("{}"), nil)
-	rendered, err := lazy.RenderSchema(ctx, target, config.Env("prod"))
+	mockMgr.On("RenderSchema", ctx, target, config.Env("prod"), false).Return([]byte("{}"), nil)
+	rendered, err := lazy.RenderSchema(ctx, target, config.Env("prod"), false)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("{}"), rendered)
+
+	mockMgr.On("RenderSchema", ctx, target, config.Env("prod"), true).Return([]byte(`{"collapsed": true}`), nil)
+	rendered, err = lazy.RenderSchema(ctx, target, config.Env("prod"), true)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(`{"collapsed": true}`), rendered)
 
 	// Test CheckChanges delegation
 	mockMgr.On("CheckChanges", ctx, config.Env("prod")).Return(nil)
@@ -1431,8 +1473,8 @@ func TestLazyManager_Delegation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test BuildDist delegation
-	mockMgr.On("BuildDist", ctx, config.Env("prod"), false).Return(nil)
-	err = lazy.BuildDist(ctx, config.Env("prod"), false)
+	mockMgr.On("BuildDist", ctx, config.Env("prod"), false, false).Return(nil)
+	err = lazy.BuildDist(ctx, config.Env("prod"), false, false)
 	require.NoError(t, err)
 
 	// Test WatchValidation delegation

--- a/internal/app/render_schema.go
+++ b/internal/app/render_schema.go
@@ -16,6 +16,7 @@ func NewRenderSchemaCmd(mgr Manager) *cobra.Command {
 	var keyStr string
 	var idStr string
 	var envStr string
+	var collapse bool
 
 	cmd := &cobra.Command{
 		Use:   "render-schema [target]",
@@ -25,6 +26,7 @@ func NewRenderSchemaCmd(mgr Manager) *cobra.Command {
   jsm render-schema "domain_family_1_0_0"
   jsm render-schema -k "domain_family_1_0_0" --env dev
   jsm render-schema "https://js.myorg.com/domain_family_1_0_0.schema.json"
+  jsm render-schema "domain_family_1_0_0" --collapse
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var targetArg string
@@ -56,7 +58,7 @@ func NewRenderSchemaCmd(mgr Manager) *cobra.Command {
 				target.Key = &resolvedKey
 			}
 
-			rendered, err := mgr.RenderSchema(cmd.Context(), target, config.Env(envStr))
+			rendered, err := mgr.RenderSchema(cmd.Context(), target, config.Env(envStr), collapse)
 			if err != nil {
 				return err
 			}
@@ -69,6 +71,8 @@ func NewRenderSchemaCmd(mgr Manager) *cobra.Command {
 	cmd.Flags().StringVarP(&keyStr, "key", "k", "", "Identify a target schema by its key")
 	cmd.Flags().StringVarP(&idStr, "id", "i", "", "Identify a target schema by its canonical ID")
 	cmd.Flags().StringVarP(&envStr, "env", "e", "", "The environment to use for rendering (defaults to production)")
+	cmd.Flags().BoolVarP(&collapse, "collapse", "C", false,
+		"Inline external $ref dependencies into the schema's $defs block")
 
 	return cmd
 }

--- a/internal/app/render_schema_test.go
+++ b/internal/app/render_schema_test.go
@@ -36,7 +36,7 @@ func TestNewRenderSchemaCmd(t *testing.T) {
 			setupMock: func(m *MockManager) {
 				m.On("RenderSchema", mock.Anything, mock.MatchedBy(func(rt schema.ResolvedTarget) bool {
 					return *rt.Key == baseKey
-				}), config.Env("")).Return(renderedBytes, nil)
+				}), config.Env(""), false).Return(renderedBytes, nil)
 			},
 			wantOutput: string(renderedBytes),
 		},
@@ -46,7 +46,7 @@ func TestNewRenderSchemaCmd(t *testing.T) {
 			setupMock: func(m *MockManager) {
 				m.On("RenderSchema", mock.Anything, mock.MatchedBy(func(rt schema.ResolvedTarget) bool {
 					return *rt.Key == baseKey
-				}), config.Env("prod")).Return(renderedBytes, nil)
+				}), config.Env("prod"), false).Return(renderedBytes, nil)
 			},
 			wantOutput: string(renderedBytes),
 		},
@@ -56,9 +56,19 @@ func TestNewRenderSchemaCmd(t *testing.T) {
 			setupMock: func(m *MockManager) {
 				m.On("RenderSchema", mock.Anything, mock.MatchedBy(func(rt schema.ResolvedTarget) bool {
 					return *rt.Key == baseKey
-				}), config.Env("")).Return(renderedBytes, nil)
+				}), config.Env(""), false).Return(renderedBytes, nil)
 			},
 			wantOutput: string(renderedBytes),
+		},
+		{
+			name: "Render with --collapse",
+			args: []string{"-k", "domain_family_1_0_0", "--collapse"},
+			setupMock: func(m *MockManager) {
+				m.On("RenderSchema", mock.Anything, mock.MatchedBy(func(rt schema.ResolvedTarget) bool {
+					return *rt.Key == baseKey
+				}), config.Env(""), true).Return([]byte(`{"collapsed":true}`), nil)
+			},
+			wantOutput: `{"collapsed":true}`,
 		},
 		{
 			name:        "Invalid target",
@@ -84,7 +94,7 @@ func TestNewRenderSchemaCmd(t *testing.T) {
 			setupMock: func(m *MockManager) {
 				m.On("RenderSchema", mock.Anything, mock.MatchedBy(func(rt schema.ResolvedTarget) bool {
 					return rt.Key != nil && *rt.Key == baseKey
-				}), config.Env("")).Return(renderedBytes, nil)
+				}), config.Env(""), false).Return(renderedBytes, nil)
 			},
 			wantOutput: string(renderedBytes),
 		},
@@ -98,7 +108,7 @@ func TestNewRenderSchemaCmd(t *testing.T) {
 			name: "Manager error",
 			args: []string{"domain_family_1_0_0"},
 			setupMock: func(m *MockManager) {
-				m.On("RenderSchema", mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
+				m.On("RenderSchema", mock.Anything, mock.Anything, mock.Anything, false).Return(nil, fmt.Errorf("boom"))
 			},
 			wantErr: true,
 		},

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -57,8 +57,13 @@ func (m *MockManager) CreateSchemaVersion(k schema.Key, rt schema.ReleaseType) (
 	return kNew, args.Error(1)
 }
 
-func (m *MockManager) RenderSchema(ctx context.Context, target schema.ResolvedTarget, env config.Env) ([]byte, error) {
-	args := m.Called(ctx, target, env)
+func (m *MockManager) RenderSchema(
+	ctx context.Context,
+	target schema.ResolvedTarget,
+	env config.Env,
+	collapse bool,
+) ([]byte, error) {
+	args := m.Called(ctx, target, env, collapse)
 	res, _ := args.Get(0).([]byte)
 	return res, args.Error(1)
 }
@@ -73,8 +78,8 @@ func (m *MockManager) TagDeployment(ctx context.Context, envName config.Env) err
 	return args.Error(0)
 }
 
-func (m *MockManager) BuildDist(ctx context.Context, envName config.Env, all bool) error {
-	args := m.Called(ctx, envName, all)
+func (m *MockManager) BuildDist(ctx context.Context, envName config.Env, all bool, collapse bool) error {
+	args := m.Called(ctx, envName, all, collapse)
 	return args.Error(0)
 }
 

--- a/internal/schema/dist.go
+++ b/internal/schema/dist.go
@@ -26,8 +26,8 @@ func (e *RegistryRootAtGitRootError) Error() string {
 
 // DistBuilder is an interface for building schema distributions.
 type DistBuilder interface {
-	BuildAll(ctx context.Context, env config.Env) (int, error)
-	BuildChanged(ctx context.Context, env config.Env, anchor repo.Revision) (int, error)
+	BuildAll(ctx context.Context, env config.Env, collapse bool) (int, error)
+	BuildChanged(ctx context.Context, env config.Env, anchor repo.Revision, collapse bool) (int, error)
 	SetNumWorkers(n int)
 }
 
@@ -68,7 +68,7 @@ func (b *FSDistBuilder) SetNumWorkers(n int) {
 }
 
 // BuildAll renders all schemas in the registry in parallel for the given environment.
-func (b *FSDistBuilder) BuildAll(ctx context.Context, env config.Env) (int, error) {
+func (b *FSDistBuilder) BuildAll(ctx context.Context, env config.Env, collapse bool) (int, error) {
 	if err := b.ensureDistDir(env); err != nil {
 		return 0, err
 	}
@@ -112,7 +112,7 @@ Loop:
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			if rErr := b.renderAndWrite(runCtx, env, k); rErr != nil {
+			if rErr := b.renderAndWrite(runCtx, env, k, collapse); rErr != nil {
 				errOnce.Do(func() {
 					finalErr = rErr
 					cancelRun()
@@ -140,7 +140,12 @@ Loop:
 }
 
 // BuildChanged renders schemas that have changed since the given anchor for the given environment.
-func (b *FSDistBuilder) BuildChanged(ctx context.Context, env config.Env, anchor repo.Revision) (int, error) {
+func (b *FSDistBuilder) BuildChanged(
+	ctx context.Context,
+	env config.Env,
+	anchor repo.Revision,
+	collapse bool,
+) (int, error) {
 	if err := b.ensureDistDir(env); err != nil {
 		return 0, err
 	}
@@ -165,7 +170,7 @@ func (b *FSDistBuilder) BuildChanged(ctx context.Context, env config.Env, anchor
 			continue
 		}
 
-		if rwErr := b.renderAndWrite(ctx, env, k); rwErr != nil {
+		if rwErr := b.renderAndWrite(ctx, env, k, collapse); rwErr != nil {
 			return count, rwErr
 		}
 		count++
@@ -175,7 +180,7 @@ func (b *FSDistBuilder) BuildChanged(ctx context.Context, env config.Env, anchor
 }
 
 // renderAndWrite renders a single schema and writes it to the dist directory for the given environment.
-func (b *FSDistBuilder) renderAndWrite(ctx context.Context, env config.Env, k Key) error {
+func (b *FSDistBuilder) renderAndWrite(ctx context.Context, env config.Env, k Key, collapse bool) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -195,6 +200,16 @@ func (b *FSDistBuilder) renderAndWrite(ctx context.Context, env config.Env, k Ke
 		return fmt.Errorf("failed to render schema %s: %w", k, err)
 	}
 
+	output := ri.Rendered
+	if collapse {
+		inliner := NewInliner(b.registry, ec)
+		collapsed, cErr := inliner.Collapse(ri.Rendered)
+		if cErr != nil {
+			return fmt.Errorf("failed to collapse schema %s: %w", k, cErr)
+		}
+		output = collapsed
+	}
+
 	envDir := filepath.Join(b.distDir, string(env))
 	subDir := "private"
 	if s.IsPublic() {
@@ -202,7 +217,7 @@ func (b *FSDistBuilder) renderAndWrite(ctx context.Context, env config.Env, k Ke
 	}
 
 	outputPath := filepath.Join(envDir, subDir, s.Filename())
-	if wErr := os.WriteFile(outputPath, ri.Rendered, 0o600); wErr != nil {
+	if wErr := os.WriteFile(outputPath, output, 0o600); wErr != nil {
 		return fmt.Errorf("failed to write schema %s: %w", k, wErr)
 	}
 

--- a/internal/schema/dist_test.go
+++ b/internal/schema/dist_test.go
@@ -64,7 +64,7 @@ func TestDistBuilder_BuildAll(t *testing.T) {
 		builder, err := NewFSDistBuilder(context.Background(), reg, cfg, &mockGitter{}, "dist")
 		require.NoError(t, err)
 
-		count, err := builder.BuildAll(context.Background(), "production")
+		count, err := builder.BuildAll(context.Background(), "production", false)
 		require.NoError(t, err)
 		assert.Equal(t, 1, count)
 
@@ -82,6 +82,119 @@ func TestDistBuilder_BuildAll(t *testing.T) {
 		assert.Len(t, files, 1)
 	})
 
+	t.Run("collapse success", func(t *testing.T) {
+		t.Parallel()
+
+		regDir := t.TempDir()
+		distDir := filepath.Join(filepath.Dir(regDir), "dist")
+		envDir := filepath.Join(distDir, "production")
+
+		configContent := `
+schemaStoreBaseURI: https://example.com
+environments:
+  production:
+    isProduction: true
+    allowSchemaMutation: false
+    publicUrlRoot: https://example.com/public
+    privateUrlRoot: https://example.com/private
+`
+		require.NoError(t, os.WriteFile(
+			filepath.Join(regDir, "json-schema-manager-config.yml"),
+			[]byte(configContent),
+			0o600,
+		))
+
+		// Create two schemas: A references B
+		dirA := filepath.Join(regDir, "domain", "a", "1", "0", "0")
+		require.NoError(t, os.MkdirAll(dirA, 0o755))
+		schemaA := filepath.Join(dirA, "domain_a_1_0_0.schema.json")
+		contentA := []byte(`{
+			"$id": "https://example.com/private/domain_a_1_0_0.schema.json",
+			"type": "object",
+			"properties": {
+				"b": { "$ref": "https://example.com/private/domain_b_1_0_0.schema.json" }
+			}
+		}`)
+		require.NoError(t, os.WriteFile(schemaA, contentA, 0o600))
+
+		dirB := filepath.Join(regDir, "domain", "b", "1", "0", "0")
+		require.NoError(t, os.MkdirAll(dirB, 0o755))
+		schemaB := filepath.Join(dirB, "domain_b_1_0_0.schema.json")
+		contentB := []byte(`{
+			"$id": "https://example.com/private/domain_b_1_0_0.schema.json",
+			"type": "string"
+		}`)
+		require.NoError(t, os.WriteFile(schemaB, contentB, 0o600))
+
+		reg, err := NewRegistry(regDir, &mockCompiler{}, fsh.NewPathResolver(), fsh.NewEnvProvider())
+		require.NoError(t, err)
+
+		cfg, err := reg.Config()
+		require.NoError(t, err)
+
+		builder, err := NewFSDistBuilder(context.Background(), reg, cfg, &mockGitter{}, "dist")
+		require.NoError(t, err)
+
+		count, err := builder.BuildAll(context.Background(), "production", true)
+		require.NoError(t, err)
+		assert.Equal(t, 2, count)
+
+		// Verify schema A has schema B in inlined $defs
+		aBuiltPath := filepath.Join(envDir, "private", "domain_a_1_0_0.schema.json")
+		bBuiltPath := filepath.Join(envDir, "private", "domain_b_1_0_0.schema.json")
+
+		aBuilt, err := os.ReadFile(aBuiltPath)
+		require.NoError(t, err)
+		bBuilt, err := os.ReadFile(bBuiltPath)
+		require.NoError(t, err)
+
+		assert.Contains(t, string(aBuilt), `"$defs":`)
+		assert.Contains(t, string(aBuilt), `"domain_b_1_0_0": {`)
+		assert.Contains(t, string(aBuilt), `"#/$defs/domain_b_1_0_0"`)
+
+		assert.NotContains(t, string(bBuilt), `"$defs":`)
+	})
+
+	t.Run("collapse fails", func(t *testing.T) {
+		t.Parallel()
+		regDir := t.TempDir()
+
+		require.NoError(t, os.MkdirAll(filepath.Join(regDir, "domain", "a", "1", "0", "0"), 0o755))
+
+		// Schema A references B, but B doesn't exist. This will cause Collapse to fail.
+		schemaA := filepath.Join(regDir, "domain", "a", "1", "0", "0", "domain_a_1_0_0.schema.json")
+		contentA := []byte(`{
+			"$id": "https://example.com/private/domain_a_1_0_0.schema.json",
+			"type": "object",
+			"properties": {
+				"b": { "$ref": "https://example.com/private/domain_b_1_0_0.schema.json" }
+			}
+		}`)
+		require.NoError(t, os.WriteFile(schemaA, contentA, 0o600))
+
+		// Create a config file to bypass simpleTestConfig if needed, but we can reuse the default Mock setup
+		cfgData := `environments: {production: {publicUrlRoot: 'https://p', ` +
+			`privateUrlRoot: 'https://example.com/private', isProduction: true}}`
+		require.NoError(t, os.WriteFile(
+			filepath.Join(regDir, "json-schema-manager-config.yml"),
+			[]byte(cfgData),
+			0o600,
+		))
+		reg, err := NewRegistry(regDir, &mockCompiler{}, fsh.NewPathResolver(), fsh.NewEnvProvider())
+		require.NoError(t, err)
+
+		cfg, err := reg.Config()
+		require.NoError(t, err)
+
+		builder, err := NewFSDistBuilder(context.Background(), reg, cfg, &mockGitter{}, "dist")
+		require.NoError(t, err)
+
+		// Collapse should fail because B does not exist
+		_, err = builder.BuildAll(context.Background(), "production", true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to collapse schema")
+	})
+
 	t.Run("context cancellation", func(t *testing.T) {
 		t.Parallel()
 
@@ -95,7 +208,7 @@ func TestDistBuilder_BuildAll(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // Cancel immediately
 
-		_, err = builder.BuildAll(ctx, "production")
+		_, err = builder.BuildAll(ctx, "production", false)
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 
@@ -134,7 +247,7 @@ func TestDistBuilder_BuildAll(t *testing.T) {
 		builder, err := NewFSDistBuilder(context.Background(), reg, cfg, &mockGitter{}, "dist")
 		require.NoError(t, err)
 
-		_, err = builder.BuildAll(context.Background(), "production")
+		_, err = builder.BuildAll(context.Background(), "production", false)
 		require.Error(t, err)
 	})
 
@@ -151,7 +264,7 @@ func TestDistBuilder_BuildAll(t *testing.T) {
 		// Delete the registry root to make NewSearcher fail
 		require.NoError(t, os.RemoveAll(reg.rootDirectory))
 
-		_, err = builder.BuildAll(context.Background(), "production")
+		_, err = builder.BuildAll(context.Background(), "production", false)
 		require.Error(t, err)
 	})
 
@@ -191,7 +304,7 @@ func TestDistBuilder_BuildAll(t *testing.T) {
 		// Run BuildAll in a goroutine
 		errC := make(chan error, 1)
 		go func() {
-			_, bErr := builder.BuildAll(ctx, "production")
+			_, bErr := builder.BuildAll(ctx, "production", false)
 			errC <- bErr
 		}()
 
@@ -223,7 +336,7 @@ func TestDistBuilder_BuildAll(t *testing.T) {
 		builder, err := NewFSDistBuilder(context.Background(), reg, cfg, &mockGitter{}, "dist")
 		require.NoError(t, err)
 
-		_, err = builder.BuildAll(context.Background(), "production")
+		_, err = builder.BuildAll(context.Background(), "production", false)
 		require.Error(t, err)
 	})
 }
@@ -256,7 +369,7 @@ func TestDistBuilder_renderAndWrite(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		err = builder.renderAndWrite(ctx, "production", Key("domain_test_1_0_0"))
+		err = builder.renderAndWrite(ctx, "production", Key("domain_test_1_0_0"), false)
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 
@@ -274,7 +387,7 @@ func TestDistBuilder_renderAndWrite(t *testing.T) {
 			distDir:  distDir,
 		}
 
-		err = builder.renderAndWrite(context.Background(), "invalid", Key("domain_test_1_0_0"))
+		err = builder.renderAndWrite(context.Background(), "invalid", Key("domain_test_1_0_0"), false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to get environment config")
 	})
@@ -293,7 +406,7 @@ func TestDistBuilder_renderAndWrite(t *testing.T) {
 			distDir:  distDir,
 		}
 
-		err = builder.renderAndWrite(context.Background(), "production", Key("nonexistent_1_0_0"))
+		err = builder.renderAndWrite(context.Background(), "production", Key("nonexistent_1_0_0"), false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to get schema")
 	})
@@ -321,7 +434,7 @@ func TestDistBuilder_renderAndWrite(t *testing.T) {
 		require.NoError(t, os.Chmod(envDir, 0o000))
 		defer func() { _ = os.Chmod(envDir, 0o755) }()
 
-		err = builder.renderAndWrite(context.Background(), "production", Key("domain_test_1_0_0"))
+		err = builder.renderAndWrite(context.Background(), "production", Key("domain_test_1_0_0"), false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to write schema")
 	})
@@ -347,7 +460,7 @@ func TestDistBuilder_renderAndWrite(t *testing.T) {
 			distDir:  distDir,
 		}
 
-		err = builder.renderAndWrite(context.Background(), "production", Key("domain_test_1_0_0"))
+		err = builder.renderAndWrite(context.Background(), "production", Key("domain_test_1_0_0"), false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to render schema")
 	})
@@ -375,7 +488,7 @@ func TestDistBuilder_BuildChanged(t *testing.T) {
 		builder, err := NewFSDistBuilder(context.Background(), reg, cfg, gitter, "dist")
 		require.NoError(t, err)
 
-		count, err := builder.BuildChanged(context.Background(), "production", repo.Revision("HEAD"))
+		count, err := builder.BuildChanged(context.Background(), "production", repo.Revision("HEAD"), false)
 		require.NoError(t, err)
 		assert.Equal(t, 1, count)
 
@@ -401,7 +514,7 @@ func TestDistBuilder_BuildChanged(t *testing.T) {
 		builder, err := NewFSDistBuilder(context.Background(), reg, cfg, gitter, "dist")
 		require.NoError(t, err)
 
-		count, err := builder.BuildChanged(context.Background(), "production", repo.Revision("HEAD"))
+		count, err := builder.BuildChanged(context.Background(), "production", repo.Revision("HEAD"), false)
 		require.NoError(t, err)
 		assert.Equal(t, 0, count)
 	})
@@ -425,7 +538,7 @@ func TestDistBuilder_BuildChanged(t *testing.T) {
 		builder, err := NewFSDistBuilder(context.Background(), reg, cfg, gitter, "dist")
 		require.NoError(t, err)
 
-		count, err := builder.BuildChanged(context.Background(), "production", repo.Revision("HEAD"))
+		count, err := builder.BuildChanged(context.Background(), "production", repo.Revision("HEAD"), false)
 		require.NoError(t, err)
 		assert.Equal(t, 1, count, "deleted schemas should be skipped")
 	})
@@ -445,7 +558,7 @@ func TestDistBuilder_BuildChanged(t *testing.T) {
 		builder, err := NewFSDistBuilder(context.Background(), reg, cfg, gitter, "dist")
 		require.NoError(t, err)
 
-		_, err = builder.BuildChanged(context.Background(), "production", repo.Revision("HEAD"))
+		_, err = builder.BuildChanged(context.Background(), "production", repo.Revision("HEAD"), false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "git failed")
 	})
@@ -469,7 +582,7 @@ func TestDistBuilder_BuildChanged(t *testing.T) {
 		builder, err := NewFSDistBuilder(context.Background(), reg, cfg, gitter, "dist")
 		require.NoError(t, err)
 
-		count, err := builder.BuildChanged(context.Background(), "production", repo.Revision("HEAD"))
+		count, err := builder.BuildChanged(context.Background(), "production", repo.Revision("HEAD"), false)
 		require.NoError(t, err)
 		assert.Equal(t, 1, count, "should skip invalid paths and process valid ones")
 	})
@@ -507,7 +620,7 @@ func TestDistBuilder_BuildChanged(t *testing.T) {
 			cancel()
 		}()
 
-		_, err = builder.BuildChanged(ctx, "production", repo.Revision("HEAD"))
+		_, err = builder.BuildChanged(ctx, "production", repo.Revision("HEAD"), false)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, context.Canceled)
 	})
@@ -537,7 +650,7 @@ func TestDistBuilder_BuildChanged(t *testing.T) {
 			return nil, errors.New("worker failed")
 		}
 
-		_, err = builder.BuildChanged(context.Background(), "production", repo.Revision("HEAD"))
+		_, err = builder.BuildChanged(context.Background(), "production", repo.Revision("HEAD"), false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "worker failed")
 	})
@@ -557,7 +670,7 @@ func TestDistBuilder_BuildChanged(t *testing.T) {
 		builder, err := NewFSDistBuilder(context.Background(), reg, cfg, &mockGitter{}, "dist")
 		require.NoError(t, err)
 
-		_, err = builder.BuildChanged(context.Background(), "production", repo.Revision("HEAD"))
+		_, err = builder.BuildChanged(context.Background(), "production", repo.Revision("HEAD"), false)
 		require.Error(t, err)
 	})
 }
@@ -610,7 +723,7 @@ environments:
 		require.NoError(t, os.MkdirAll(filepath.Join(envDir, "private"), 0o755))
 		defer func() { _ = os.Chmod(filepath.Join(envDir, "private"), 0o755) }()
 
-		_, err = builder.BuildAll(context.Background(), "production")
+		_, err = builder.BuildAll(context.Background(), "production", false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to write schema")
 	})
@@ -640,7 +753,7 @@ environments:
 			cancel()
 		}()
 
-		_, err = builder.BuildAll(ctx, "production")
+		_, err = builder.BuildAll(ctx, "production", false)
 		_ = err
 	})
 }
@@ -903,7 +1016,7 @@ environments:
 	builder, err := NewFSDistBuilder(context.Background(), reg, cfg, &mockGitter{}, "dist")
 	require.NoError(t, err)
 
-	count, err := builder.BuildAll(context.Background(), "production")
+	count, err := builder.BuildAll(context.Background(), "production", false)
 	require.NoError(t, err)
 	assert.Equal(t, 2, count)
 

--- a/internal/schema/inliner.go
+++ b/internal/schema/inliner.go
@@ -1,0 +1,166 @@
+package schema
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/bitshepherds/json-schema-manager/internal/config"
+)
+
+// Inliner collapses external $ref references to JSM-managed schemas into internal
+// #/$defs/<key> references, collecting the referenced schema bodies into a $defs block.
+// This process is recursive: if a referenced schema itself references other schemas,
+// those are also inlined. The result is a fully self-contained JSON Schema.
+type Inliner struct {
+	registry *Registry
+	envCfg   *config.EnvConfig
+}
+
+// NewInliner creates a new Inliner for the given registry and environment configuration.
+func NewInliner(r *Registry, ec *config.EnvConfig) *Inliner {
+	return &Inliner{
+		registry: r,
+		envCfg:   ec,
+	}
+}
+
+// Collapse takes a rendered JSON Schema and returns a version with all external $ref
+// references to JSM-managed schemas resolved into #/$defs/<key> references.
+// Referenced schema bodies are collected in a top-level $defs block.
+// The $id property is stripped from each inlined schema, as the schema key
+// serves as the unique identifier in the $defs block.
+func (inl *Inliner) Collapse(rendered []byte) ([]byte, error) {
+	var doc map[string]any
+	if err := json.Unmarshal(rendered, &doc); err != nil {
+		return nil, err
+	}
+
+	defs := make(map[string]any)
+	visited := make(map[Key]bool)
+
+	if err := inl.rewriteRefs(doc, defs, visited); err != nil {
+		return nil, err
+	}
+
+	if len(defs) > 0 {
+		existing, _ := doc["$defs"].(map[string]any)
+		if existing == nil {
+			existing = make(map[string]any)
+		}
+		for k, v := range defs {
+			existing[k] = v
+		}
+		doc["$defs"] = existing
+	}
+
+	return json.MarshalIndent(doc, "", "  ")
+}
+
+// rewriteRefs walks the JSON tree, replacing $ref values that match JSM-managed
+// schema URLs with #/$defs/<key> references. For each matched reference, the
+// referenced schema body is rendered and added to the defs accumulator.
+func (inl *Inliner) rewriteRefs(node any, defs map[string]any, visited map[Key]bool) error {
+	switch v := node.(type) {
+	case map[string]any:
+		if err := inl.processObject(v, defs, visited); err != nil {
+			return err
+		}
+	case []any:
+		for _, item := range v {
+			if err := inl.rewriteRefs(item, defs, visited); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// processObject handles a single JSON object node, checking for $ref and recursing
+// into child values.
+func (inl *Inliner) processObject(obj, defs map[string]any, visited map[Key]bool) error {
+	if err := inl.handleRef(obj, defs, visited); err != nil {
+		return err
+	}
+
+	for k, val := range obj {
+		if k == "$ref" {
+			continue
+		}
+		if err := inl.rewriteRefs(val, defs, visited); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// handleRef checks for a $ref in the object, and if it's a JSM-managed schema,
+// inlines it into the defs accumulator.
+func (inl *Inliner) handleRef(obj, defs map[string]any, visited map[Key]bool) error {
+	ref, ok := obj["$ref"].(string)
+	if !ok {
+		return nil
+	}
+
+	key, matched := inl.matchJSMRef(ref)
+	if !matched {
+		return nil
+	}
+
+	obj["$ref"] = "#/$defs/" + string(key)
+	if visited[key] {
+		return nil
+	}
+
+	visited[key] = true
+	defBody, err := inl.renderDef(key)
+	if err != nil {
+		return err
+	}
+	defs[string(key)] = defBody
+
+	// Recursively process the inlined definition for its own refs
+	return inl.rewriteRefs(defBody, defs, visited)
+}
+
+// matchJSMRef checks whether a $ref string is a canonical URL for a JSM-managed schema.
+// It attempts to match against both the public and private URL roots for the current
+// environment. Returns the schema Key and true if matched, or empty and false otherwise.
+func (inl *Inliner) matchJSMRef(ref string) (Key, bool) {
+	for _, urlRoot := range []string{inl.envCfg.PublicURLRoot, inl.envCfg.PrivateURLRoot} {
+		base := urlRoot
+		if !strings.HasSuffix(base, "/") {
+			base += "/"
+		}
+		if strings.HasPrefix(ref, base) && strings.HasSuffix(ref, SchemaSuffix) {
+			stem := ref[len(base) : len(ref)-len(SchemaSuffix)]
+			if k, err := NewKey(stem); err == nil {
+				return k, true
+			}
+		}
+	}
+	return "", false
+}
+
+// renderDef renders the referenced schema and returns its body as a map, with
+// the $id property stripped.
+func (inl *Inliner) renderDef(k Key) (map[string]any, error) {
+	s, err := inl.registry.GetSchemaByKey(k)
+	if err != nil {
+		return nil, err
+	}
+
+	ri, err := inl.registry.CoordinateRender(s, inl.envCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(ri.Rendered, &body); err != nil {
+		return nil, err
+	}
+
+	// Strip $id as the schema key serves as the unique identifier in $defs
+	delete(body, "$id")
+
+	return body, nil
+}

--- a/internal/schema/inliner_test.go
+++ b/internal/schema/inliner_test.go
@@ -1,0 +1,549 @@
+package schema
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitshepherds/json-schema-manager/internal/fsh"
+	"github.com/bitshepherds/json-schema-manager/internal/validator"
+)
+
+func setupInlinerTestRegistry(t *testing.T) *Registry {
+	t.Helper()
+	return setupTestRegistry(t)
+}
+
+func TestInliner_SingleRef(t *testing.T) {
+	t.Parallel()
+
+	r := setupInlinerTestRegistry(t)
+	depKey := Key("domain_address_1_2_3")
+	createSchemaFiles(t, r, schemaMap{
+		depKey: `{"$id": "{{ ID }}", "type": "object", "properties": {"city": {"type": "string"}}}`,
+	})
+
+	ec := r.config.ProductionEnvConfig()
+
+	// Pre-render the dependency so it's available for inlining
+	depSchema, err := r.GetSchemaByKey(depKey)
+	require.NoError(t, err)
+	_, err = r.CoordinateRender(depSchema, ec)
+	require.NoError(t, err)
+
+	depID := depSchema.CanonicalID(ec)
+
+	// Build a rendered schema that references the dependency
+	rendered := `{
+  "$id": "https://json-schemas.internal.myorg.io/main_schema_1_0_0.schema.json",
+  "type": "object",
+  "properties": {
+    "shipping_address": { "$ref": "` + string(depID) + `" },
+    "billing_address": { "$ref": "` + string(depID) + `" }
+  }
+}`
+
+	inliner := NewInliner(r, ec)
+	result, err := inliner.Collapse([]byte(rendered))
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(result, &doc))
+
+	// Verify $refs were rewritten
+	props, ok := doc["properties"].(map[string]any)
+	require.True(t, ok)
+	shipping, ok := props["shipping_address"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "#/$defs/domain_address_1_2_3", shipping["$ref"])
+
+	billing, ok := props["billing_address"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "#/$defs/domain_address_1_2_3", billing["$ref"])
+
+	// Verify $defs was populated
+	defs, ok := doc["$defs"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, defs, "domain_address_1_2_3")
+
+	defBody, ok := defs["domain_address_1_2_3"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "object", defBody["type"])
+	assert.NotContains(t, defBody, "$id", "$id should be stripped from inlined $defs")
+}
+
+func TestInliner_MultipleRefsToSame(t *testing.T) {
+	t.Parallel()
+
+	r := setupTestRegistry(t)
+	depKey := Key("domain_shared_1_0_0")
+	createSchemaFiles(t, r, schemaMap{
+		depKey: `{"$id": "{{ ID }}", "type": "string"}`,
+	})
+
+	ec := r.config.ProductionEnvConfig()
+	depSchema, err := r.GetSchemaByKey(depKey)
+	require.NoError(t, err)
+	_, err = r.CoordinateRender(depSchema, ec)
+	require.NoError(t, err)
+
+	depID := depSchema.CanonicalID(ec)
+
+	rendered := `{
+  "type": "object",
+  "properties": {
+    "a": { "$ref": "` + string(depID) + `" },
+    "b": { "$ref": "` + string(depID) + `" }
+  }
+}`
+
+	inliner := NewInliner(r, ec)
+	result, err := inliner.Collapse([]byte(rendered))
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(result, &doc))
+
+	defs, ok := doc["$defs"].(map[string]any)
+	require.True(t, ok)
+	assert.Len(t, defs, 1, "should have exactly one $defs entry for the shared schema")
+}
+
+func TestInliner_TransitiveRefs(t *testing.T) {
+	t.Parallel()
+
+	r := setupTestRegistry(t)
+
+	// C has no dependencies
+	cKey := Key("domain_c_1_0_0")
+	createSchemaFiles(t, r, schemaMap{
+		cKey: `{"$id": "{{ ID }}", "type": "string"}`,
+	})
+
+	// B references C via JSM template (will resolve to C's canonical ID)
+	bKey := Key("domain_b_1_0_0")
+	createSchemaFiles(t, r, schemaMap{
+		bKey: `{"$id": "{{ ID }}", "type": "object", "properties": {"c": {"$ref": "{{ JSM %%domain_c_1_0_0%% }}"}}}`,
+	})
+
+	ec := r.config.ProductionEnvConfig()
+
+	// Pre-render B (which will also render C as a side effect)
+	bSchema, err := r.GetSchemaByKey(bKey)
+	require.NoError(t, err)
+	bRI, err := r.CoordinateRender(bSchema, ec)
+	require.NoError(t, err)
+
+	bID := bSchema.CanonicalID(ec)
+
+	// A references B
+	rendered := `{
+  "type": "object",
+  "properties": {
+    "b": { "$ref": "` + string(bID) + `" }
+  }
+}`
+
+	inliner := NewInliner(r, ec)
+	result, err := inliner.Collapse([]byte(rendered))
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(result, &doc))
+
+	defs, ok := doc["$defs"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, defs, "domain_b_1_0_0", "B should be in $defs")
+	assert.Contains(t, defs, "domain_c_1_0_0", "C should be in $defs (transitive)")
+
+	// Verify B's $ref to C was also rewritten
+	bDef, ok := defs["domain_b_1_0_0"].(map[string]any)
+	require.True(t, ok)
+	bProps, ok := bDef["properties"].(map[string]any)
+	require.True(t, ok)
+	cRef, ok := bProps["c"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "#/$defs/domain_c_1_0_0", cRef["$ref"])
+
+	// Ensure the rendered B content was valid before inlining (sanity check)
+	assert.NotEmpty(t, bRI.Rendered)
+}
+
+func TestInliner_NoRefs(t *testing.T) {
+	t.Parallel()
+
+	r := setupTestRegistry(t)
+	ec := r.config.ProductionEnvConfig()
+
+	rendered := `{"type": "object", "properties": {"name": {"type": "string"}}}`
+
+	inliner := NewInliner(r, ec)
+	result, err := inliner.Collapse([]byte(rendered))
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(result, &doc))
+
+	assert.NotContains(t, doc, "$defs", "no $defs should be added when there are no external refs")
+}
+
+func TestInliner_NonJSMRef(t *testing.T) {
+	t.Parallel()
+
+	r := setupTestRegistry(t)
+	ec := r.config.ProductionEnvConfig()
+
+	rendered := `{
+  "type": "object",
+  "properties": {
+    "ext": { "$ref": "https://external.example.com/some_schema.json" },
+    "local": { "$ref": "#/definitions/localThing" }
+  }
+}`
+
+	inliner := NewInliner(r, ec)
+	result, err := inliner.Collapse([]byte(rendered))
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(result, &doc))
+
+	// External and local refs should be left untouched
+	props, ok := doc["properties"].(map[string]any)
+	require.True(t, ok)
+	ext, ok := props["ext"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "https://external.example.com/some_schema.json", ext["$ref"])
+
+	local, ok := props["local"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "#/definitions/localThing", local["$ref"])
+
+	assert.NotContains(t, doc, "$defs")
+}
+
+func TestInliner_ExistingDefs(t *testing.T) {
+	t.Parallel()
+
+	r := setupTestRegistry(t)
+	depKey := Key("domain_dep_1_0_0")
+	createSchemaFiles(t, r, schemaMap{
+		depKey: `{"$id": "{{ ID }}", "type": "number"}`,
+	})
+
+	ec := r.config.ProductionEnvConfig()
+	depSchema, err := r.GetSchemaByKey(depKey)
+	require.NoError(t, err)
+	_, err = r.CoordinateRender(depSchema, ec)
+	require.NoError(t, err)
+
+	depID := depSchema.CanonicalID(ec)
+
+	rendered := `{
+  "type": "object",
+  "properties": {
+    "d": { "$ref": "` + string(depID) + `" }
+  },
+  "$defs": {
+    "existingDef": { "type": "string" }
+  }
+}`
+
+	inliner := NewInliner(r, ec)
+	result, err := inliner.Collapse([]byte(rendered))
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(result, &doc))
+
+	defs, ok := doc["$defs"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, defs, "existingDef", "pre-existing $defs entry should be preserved")
+	assert.Contains(t, defs, "domain_dep_1_0_0", "inlined entry should be added")
+}
+
+func TestInliner_IdStripped(t *testing.T) {
+	t.Parallel()
+
+	r := setupTestRegistry(t)
+	depKey := Key("domain_withid_1_0_0")
+	createSchemaFiles(t, r, schemaMap{
+		depKey: `{"$id": "{{ ID }}", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object"}`,
+	})
+
+	ec := r.config.ProductionEnvConfig()
+	depSchema, err := r.GetSchemaByKey(depKey)
+	require.NoError(t, err)
+	_, err = r.CoordinateRender(depSchema, ec)
+	require.NoError(t, err)
+
+	depID := depSchema.CanonicalID(ec)
+
+	rendered := `{
+  "type": "object",
+  "properties": {
+    "w": { "$ref": "` + string(depID) + `" }
+  }
+}`
+
+	inliner := NewInliner(r, ec)
+	result, err := inliner.Collapse([]byte(rendered))
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(result, &doc))
+
+	defs, ok := doc["$defs"].(map[string]any)
+	require.True(t, ok)
+	defBody, ok := defs["domain_withid_1_0_0"].(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, defBody, "$id", "$id should be stripped from inlined schemas")
+	assert.Contains(t, defBody, "$schema", "other properties should be preserved")
+}
+
+func TestInliner_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	r := setupTestRegistry(t)
+	ec := r.config.ProductionEnvConfig()
+
+	inliner := NewInliner(r, ec)
+	_, err := inliner.Collapse([]byte("not json"))
+	require.Error(t, err)
+}
+
+func TestInliner_RefInArray(t *testing.T) {
+	t.Parallel()
+
+	r := setupTestRegistry(t)
+	depKey := Key("domain_item_1_0_0")
+	createSchemaFiles(t, r, schemaMap{
+		depKey: `{"$id": "{{ ID }}", "type": "string"}`,
+	})
+
+	ec := r.config.ProductionEnvConfig()
+	depSchema, err := r.GetSchemaByKey(depKey)
+	require.NoError(t, err)
+	_, err = r.CoordinateRender(depSchema, ec)
+	require.NoError(t, err)
+
+	depID := depSchema.CanonicalID(ec)
+
+	rendered := `{
+  "type": "object",
+  "oneOf": [
+    { "$ref": "` + string(depID) + `" },
+    { "type": "number" }
+  ]
+}`
+
+	inliner := NewInliner(r, ec)
+	result, err := inliner.Collapse([]byte(rendered))
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(result, &doc))
+
+	oneOf, ok := doc["oneOf"].([]any)
+	require.True(t, ok)
+	first, ok := oneOf[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "#/$defs/domain_item_1_0_0", first["$ref"])
+
+	defs, ok := doc["$defs"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, defs, "domain_item_1_0_0")
+}
+
+func TestInliner_Errors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid json input", func(t *testing.T) {
+		t.Parallel()
+		r := setupInlinerTestRegistry(t)
+		inl := NewInliner(r, r.config.ProductionEnvConfig())
+		_, err := inl.Collapse([]byte(`{invalid json}`))
+		require.Error(t, err)
+	})
+
+	t.Run("missing ref schema - hits renderDef GetSchemaByKey error", func(t *testing.T) {
+		t.Parallel()
+		r := setupInlinerTestRegistry(t)
+		inl := NewInliner(r, r.config.ProductionEnvConfig())
+		// Pattern matches but no such schema file
+		rendered := `{"$ref": "https://json-schemas.myorg.io/domain_family_missing_1_0_0.schema.json"}`
+		_, err := inl.Collapse([]byte(rendered))
+		require.Error(t, err)
+	})
+
+	t.Run("nested ref schema error - hits processObject rewriteRefs error", func(t *testing.T) {
+		t.Parallel()
+		r := setupInlinerTestRegistry(t)
+		ec := r.config.ProductionEnvConfig()
+		inl := NewInliner(r, ec)
+
+		// B exists and is valid, but refers to C which is missing
+		keyB := Key("domain_family_b_1_0_0")
+		keyC := "https://json-schemas.myorg.io/domain_family_c_1_0_0.schema.json"
+		createSchemaFiles(t, r, schemaMap{
+			keyB: `{"properties": {"c": {"$ref": "` + keyC + `"}}}`,
+		})
+
+		rendered := `{"$ref": "https://json-schemas.myorg.io/domain_family_b_1_0_0.schema.json"}`
+		_, err := inl.Collapse([]byte(rendered))
+		require.Error(t, err)
+	})
+
+	t.Run("renderDef coordinate render error directly", func(t *testing.T) {
+		t.Parallel()
+		r := setupInlinerTestRegistry(t)
+		inl := NewInliner(r, r.config.ProductionEnvConfig())
+
+		key := Key("domain_family_broken_direct_1_0_0")
+		createSchemaFiles(t, r, schemaMap{
+			key: `{"type": "{{ if }}"}`,
+		})
+
+		_, err := inl.renderDef(key)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing value for if")
+	})
+
+	t.Run("unrenderable ref schema - hits renderDef CoordinateRender error", func(t *testing.T) {
+		t.Parallel()
+		r := setupInlinerTestRegistry(t)
+		ec := r.config.ProductionEnvConfig()
+		inl := NewInliner(r, ec)
+
+		// Configure compiler to fail during rendering/compilation
+		mock, ok := r.compiler.(*mockCompiler)
+		require.True(t, ok)
+		mock.CompileFunc = func(_ string) (validator.Validator, error) {
+			return nil, &InvalidJSONSchemaError{Path: "mock", Wrapped: os.ErrInvalid}
+		}
+
+		key := Key("domain_family_test_1_0_0")
+		createSchemaFiles(t, r, schemaMap{
+			key: `{"type": "string"}`,
+		})
+
+		rendered := `{"$ref": "https://json-schemas.myorg.io/domain_family_test_1_0_0.schema.json"}`
+		_, err := inl.Collapse([]byte(rendered))
+		require.Error(t, err)
+	})
+
+	t.Run("matchJSMRef ensures trailing slash", func(t *testing.T) {
+		t.Parallel()
+		regDir := t.TempDir()
+		badConfig := `
+environments:
+  prod:
+    publicUrlRoot: "https://no-slash.io"
+    privateUrlRoot: "https://internal.no-slash.io"
+    isProduction: true
+`
+		err := os.WriteFile(filepath.Join(regDir, "json-schema-manager-config.yml"), []byte(badConfig), 0o600)
+		require.NoError(t, err)
+
+		r, err := NewRegistry(regDir, &mockCompiler{}, fsh.NewPathResolver(), fsh.NewEnvProvider())
+		require.NoError(t, err)
+
+		inl := NewInliner(r, r.config.Environments["prod"])
+
+		createSchemaFiles(t, r, schemaMap{
+			Key("domain_family_test_1_0_0"): `{"type": "string"}`,
+		})
+
+		// This should still match because matchJSMRef adds the slash
+		rendered := `{"$ref": "https://no-slash.io/domain_family_test_1_0_0.schema.json"}`
+		res, err := inl.Collapse([]byte(rendered))
+		require.NoError(t, err)
+		require.Contains(t, string(res), "$defs")
+	})
+
+	t.Run("boolean schema - hits renderDef Unmarshal error", func(t *testing.T) {
+		t.Parallel()
+		r := setupInlinerTestRegistry(t)
+		inl := NewInliner(r, r.config.ProductionEnvConfig())
+
+		key := Key("domain_family_bool_schema_1_0_0")
+		// 1. Create a valid object schema
+		createSchemaFiles(t, r, schemaMap{
+			key: `{"x-public": true}`,
+		})
+
+		// 2. Load it
+		s, err := r.GetSchemaByKey(key)
+		require.NoError(t, err)
+
+		// 3. Directly set RenderInfo with a non-object Rendered but non-nil Validator
+		// to force CoordinateRender to return it early.
+		s.mu.Lock()
+		s.computed.StoreRenderInfo("prod", RenderInfo{
+			Rendered:     []byte("true"),
+			Unmarshalled: true, // boolean schema
+			Validator:    &mockValidator{},
+		})
+		s.computed.StoreID("prod", "https://json-schemas.myorg.io/domain_family_bool_schema_1_0_0.schema.json")
+		s.mu.Unlock()
+
+		rendered := `{"$ref": "https://json-schemas.myorg.io/domain_family_bool_schema_1_0_0.schema.json"}`
+		res, err := inl.Collapse([]byte(rendered))
+		if err == nil {
+			t.Fatalf("Expected Unmarshal error but got nil. Result: %s", string(res))
+		}
+		require.Contains(t, err.Error(), "cannot unmarshal bool")
+	})
+
+	t.Run("error in array items", func(t *testing.T) {
+		t.Parallel()
+		r := setupInlinerTestRegistry(t)
+		inl := NewInliner(r, r.config.ProductionEnvConfig())
+		rendered := `{"items": [{"$ref": "https://json-schemas.myorg.io/domain_family_missing_1_0_0.schema.json"}]}`
+		_, err := inl.Collapse([]byte(rendered))
+		require.Error(t, err)
+	})
+
+	t.Run("error in deep object properties", func(t *testing.T) {
+		t.Parallel()
+		r := setupInlinerTestRegistry(t)
+		inl := NewInliner(r, r.config.ProductionEnvConfig())
+		rendered := `{"a": {"b": {"$ref": "https://json-schemas.myorg.io/domain_family_missing_1_0_0.schema.json"}}}`
+		_, err := inl.Collapse([]byte(rendered))
+		require.Error(t, err)
+	})
+
+	t.Run("hits mergeDefs and continue branches", func(t *testing.T) {
+		t.Parallel()
+		r := setupInlinerTestRegistry(t)
+		inl := NewInliner(r, r.config.ProductionEnvConfig())
+
+		key := Key("domain_family_simple_1_0_0")
+		createSchemaFiles(t, r, schemaMap{
+			key: `{"type": "string"}`,
+		})
+
+		// Full workflow to hit defs merging and the continue branch in processObject
+		rendered := `{"$ref": "https://json-schemas.myorg.io/domain_family_simple_1_0_0.schema.json", "other": "prop"}`
+		res, err := inl.Collapse([]byte(rendered))
+		require.NoError(t, err)
+		require.Contains(t, string(res), "$defs")
+		require.Contains(t, string(res), "domain_family_simple_1_0_0")
+	})
+
+	t.Run("external ref - hits matchJSMRef false branch", func(t *testing.T) {
+		t.Parallel()
+		r := setupInlinerTestRegistry(t)
+		inl := NewInliner(r, r.config.ProductionEnvConfig())
+		rendered := `{"$ref": "https://example.com/schema.json"}`
+		res, err := inl.Collapse([]byte(rendered))
+		require.NoError(t, err)
+		// Should NOT be rewritten
+		require.Contains(t, string(res), "https://example.com/schema.json")
+		require.NotContains(t, string(res), "$defs")
+	})
+}


### PR DESCRIPTION
## Objective

This PR implements the **Schema Collapsing** feature, allowing users to generate stand-alone JSON schemas. It recursively resolves external `$ref` references to other JSM-managed schemas within the same registry and inlines them into a top-level `$defs` block.

## Features

- **Inliner Component**: New high-performance component in `internal/schema` that handles recursive schema traversal and `$ref` rewriting.
- **`--collapse` / `-C` Flag**: Added to both `render-schema` and `build-dist` commands.
- **Smart Inlining**:
    - Recursively resolves transitive dependencies (e.g., A → B → C results in both B and C being inlined in A).
    - Automatically strips `$id` fields from inlined schemas, as the schema key uniquely identifies them within the parent document.
    - Preserves existing `$defs` entries while merging new ones.
    - Gracefully ignores standard external URLs (e.g., `example.com`) and local references (e.g., `#/definitions/foo`).
   
## Quality & Testing

- **100% Test Coverage**: The `Inliner` component and its integration points are fully covered by unit tests, including complex error paths (missing dependencies, circular references, invalid JSON).
- **Concurrency-Safe**: All new tests are parallel-enabled, and the implementation is optimized for the project's single-flight rendering architecture.
- **Lint-Satisfied**: All `golangci-lint` issues (including `gocognit`, `forcetypeassert`, and `lll`) have been resolved.

## Usage Examples

### Render a single schema with inlining

```bash
jsm render-schema "domain_family_1_0_0" --collapse
```

### Build a stand-alone distribution for an environment

```bash
jsm build-dist prod --collapse
```

## Configuration note

Only schemas managed by JSM within the registry are inlined. External Schema references are left in place.